### PR TITLE
Run video generation and social posting in Google Cloud

### DIFF
--- a/cloud/video-generator/Dockerfile
+++ b/cloud/video-generator/Dockerfile
@@ -1,7 +1,11 @@
 FROM node:20-bookworm-slim
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates \
+  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates gnupg \
+  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends google-cloud-cli google-cloud-cli-gsutil \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -10,12 +14,14 @@ COPY package*.json ./
 RUN npm ci --omit=dev || npm install --omit=dev
 
 COPY config ./config
+COPY data ./data
 COPY scripts ./scripts
 COPY public ./public
 COPY content ./content
 
 ENV NODE_ENV=production
 ENV FFMPEG_TIMEOUT_MS=900000
+ENV JOB_STEP_TIMEOUT_MS=1800000
 ENV GOOGLE_CLOUD_VIDEO_JOB=true
 
-CMD ["npm", "run", "videos"]
+CMD ["npm", "run", "video:social"]

--- a/cloud/video-generator/README.md
+++ b/cloud/video-generator/README.md
@@ -1,20 +1,27 @@
-# Google Cloud video generator
+# Google Cloud video + social poster
 
-This folder turns the seed-style product video generator into a Google Cloud Run Job. Use it to render the top five product videos outside Vercel.
+This Cloud Run Job renders the top five seed-style product videos, optionally saves the generated assets to Cloud Storage, and then runs the existing social media automation.
 
 ## Why this runs in Google Cloud
 
-Video rendering uses FFmpeg and can take longer than a normal web build. Vercel should serve the website. Google Cloud Run Jobs should generate the MP4 files.
+Video rendering uses FFmpeg and can take longer than a normal web build. Vercel should serve the website. Google Cloud Run Jobs should generate videos and handle social posting.
 
-## What it generates
+## What the job runs
 
-Running the job executes:
+The container command is:
 
 ```bash
-npm run videos
+npm run video:social
 ```
 
-That creates:
+That runs this sequence:
+
+1. Load configured runtime settings from Google Secret Manager.
+2. Generate all five quality seed-style product videos.
+3. Optionally copy generated MP4, JPG, and JSON plan files to Cloud Storage.
+4. Run the existing social media auto-poster.
+
+## Generated files
 
 ```text
 public/videos/NWS_014.mp4
@@ -30,12 +37,42 @@ public/videos/NWS_018.jpg
 content/generated-videos/*-quality-seed-plan.json
 ```
 
+## Google Secret Manager
+
+The job loads platform credentials and posting settings by name from Google Secret Manager. The Cloud Run Job service account needs permission to access those secret versions.
+
+```bash
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+You can add extra secret names at deploy time with:
+
+```bash
+--set-env-vars GOOGLE_SECRET_NAMES="EXTRA_NAME_ONE,EXTRA_NAME_TWO"
+```
+
+## Cloud Storage output
+
+Set a bucket and prefix to persist finished output files:
+
+```bash
+VIDEO_OUTPUT_BUCKET="natureswaysoil-videos"
+VIDEO_OUTPUT_PREFIX="seed-videos"
+```
+
+The job service account needs storage write access:
+
+```bash
+gcloud storage buckets add-iam-policy-binding "gs://natureswaysoil-videos" \
+  --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
+  --role="roles/storage.objectAdmin"
+```
+
 ## Best quality setup
 
-For the best videos, provide at least one of these:
-
-1. `PEXELS_API_KEY` as a Cloud Run Job environment variable.
-2. Your own b-roll clips in the repo:
+For better video quality, provide either a Pexels key in Secret Manager or your own b-roll clips in the repo:
 
 ```text
 public/broll/NWS_014/
@@ -46,50 +83,32 @@ public/broll/NWS_018/
 public/broll/shared/
 ```
 
-The generator uses product images, local b-roll, Pexels b-roll, and branded motion fallback scenes.
-
 ## Build and deploy
-
-Set these first:
 
 ```bash
 export PROJECT_ID="YOUR_GOOGLE_CLOUD_PROJECT_ID"
 export REGION="us-east1"
 export IMAGE="gcr.io/$PROJECT_ID/nws-video-generator:latest"
-```
+export SERVICE_ACCOUNT_EMAIL="YOUR_CLOUD_RUN_JOB_SERVICE_ACCOUNT"
 
-Build the container:
-
-```bash
 gcloud builds submit \
   --tag "$IMAGE" \
   --file cloud/video-generator/Dockerfile \
   .
-```
 
-Create or update the Cloud Run Job:
-
-```bash
 gcloud run jobs deploy nws-video-generator \
   --image "$IMAGE" \
   --region "$REGION" \
+  --service-account "$SERVICE_ACCOUNT_EMAIL" \
   --tasks 1 \
   --max-retries 0 \
   --cpu 2 \
   --memory 4Gi \
   --task-timeout 1800 \
-  --set-env-vars FFMPEG_TIMEOUT_MS=900000
+  --set-env-vars FFMPEG_TIMEOUT_MS=900000,JOB_STEP_TIMEOUT_MS=1800000,VIDEO_OUTPUT_BUCKET=natureswaysoil-videos,VIDEO_OUTPUT_PREFIX=seed-videos,NEXT_PUBLIC_SITE_URL=https://www.natureswaysoil.com
 ```
 
-If you have a Pexels key:
-
-```bash
-gcloud run jobs update nws-video-generator \
-  --region "$REGION" \
-  --set-env-vars PEXELS_API_KEY="YOUR_PEXELS_API_KEY",FFMPEG_TIMEOUT_MS=900000
-```
-
-Run the job:
+Run it:
 
 ```bash
 gcloud run jobs execute nws-video-generator \
@@ -97,6 +116,20 @@ gcloud run jobs execute nws-video-generator \
   --wait
 ```
 
-## Important output note
+## Testing switches
 
-The container writes the generated videos inside the job filesystem. For a production automation, the next step should upload finished videos to Cloud Storage or commit them back to GitHub. This PR prepares the generator to run in Google Cloud; it does not yet add the Cloud Storage upload step.
+Skip social posting while testing:
+
+```bash
+--set-env-vars SKIP_SOCIAL_POSTING=1
+```
+
+Force image-only Instagram fallback:
+
+```bash
+--set-env-vars SOCIAL_FORCE_IMAGE_ONLY=1
+```
+
+## Important note
+
+Instagram Reels require a publicly accessible video URL. If `/videos/{PRODUCT_ID}.mp4` is not yet public on the website, YouTube and X/Twitter native uploads may still work from the job filesystem, but Instagram may require the finished MP4 files to be available through the website or a public Cloud Storage URL.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint app components config data lib pages --ext .js,.ts,.tsx",
     "type-check": "tsc --noEmit",
     "videos": "node scripts/create-quality-seed-videos.mjs --all",
+    "video:social": "node scripts/cloud-video-social-job.mjs",
     "seed:videos": "node scripts/create-quality-seed-videos.mjs --all",
     "seed:video": "node scripts/create-quality-seed-videos.mjs",
     "legacy:videos": "node scripts/generate-product-videos.mjs",

--- a/scripts/cloud-video-social-job.mjs
+++ b/scripts/cloud-video-social-job.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+/**
+ * Google Cloud video + social job.
+ *
+ * Pipeline:
+ * 1. Hydrate environment variables from Google Secret Manager.
+ * 2. Generate the top-five quality seed-style videos.
+ * 3. Optionally upload videos/posters/plans to Cloud Storage.
+ * 4. Run the existing social-media auto-poster.
+ *
+ * This script is intentionally conservative: it never hardcodes credentials and it
+ * can run with only Secret Manager + platform env vars supplied by Cloud Run Job.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT = path.resolve(__dirname, '..');
+const VIDEOS_DIR = path.join(PROJECT, 'public', 'videos');
+const PLANS_DIR = path.join(PROJECT, 'content', 'generated-videos');
+const SECRET_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || process.env.PROJECT_ID;
+const SECRET_NAMES = [
+  'PEXELS_API_KEY',
+  'NEXT_PUBLIC_SITE_URL',
+  'INSTAGRAM_ACCESS_TOKEN',
+  'INSTAGRAM_IG_ID',
+  'FACEBOOK_PAGE_ID',
+  'FACEBOOK_ACCESS_TOKEN',
+  'FACEBOOK_PAGE_ACCESS_TOKEN',
+  'PINTEREST_ACCESS_TOKEN',
+  'PINTEREST_BOARD_ID',
+  'TWITTER_API_KEY',
+  'TWITTER_API_SECRET',
+  'TWITTER_ACCESS_TOKEN',
+  'TWITTER_ACCESS_TOKEN_SECRET',
+  'TWITTER_ACCESS_SECRET',
+  'TWITTER_BEARER_TOKEN',
+  'YT_CLIENT_ID',
+  'YT_CLIENT_SECRET',
+  'YT_REFRESH_TOKEN'
+];
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { cwd: PROJECT, stdio: 'inherit', timeout: Number(process.env.JOB_STEP_TIMEOUT_MS || 1800000), ...options });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed with exit ${result.status}`);
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, { cwd: PROJECT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 30000 });
+  if (result.status !== 0) return '';
+  return result.stdout.trim();
+}
+
+function secretNames() {
+  const extra = String(process.env.GOOGLE_SECRET_NAMES || '')
+    .split(',')
+    .map((x) => x.trim())
+    .filter(Boolean);
+  return [...new Set([...SECRET_NAMES, ...extra])];
+}
+
+function readSecret(secretName) {
+  if (!SECRET_PROJECT_ID) return null;
+  const resource = `projects/${SECRET_PROJECT_ID}/secrets/${secretName}/versions/latest`;
+  const value = capture('gcloud', ['secrets', 'versions', 'access', 'latest', '--secret', secretName, '--project', SECRET_PROJECT_ID]);
+  if (!value) {
+    console.log(`[Cloud Video Job] Secret not loaded or not present: ${resource}`);
+    return null;
+  }
+  return value;
+}
+
+function hydrateSecrets() {
+  console.log('[Cloud Video Job] Loading configured secrets from Google Secret Manager...');
+  if (!SECRET_PROJECT_ID) {
+    console.log('[Cloud Video Job] No Google Cloud project id detected. Using existing environment variables only.');
+    return;
+  }
+  let loaded = 0;
+  for (const name of secretNames()) {
+    if (process.env[name]) continue;
+    const value = readSecret(name);
+    if (value) {
+      process.env[name] = value;
+      loaded++;
+    }
+  }
+  console.log(`[Cloud Video Job] Loaded ${loaded} secret value(s).`);
+}
+
+function uploadOutputsToCloudStorage() {
+  const bucket = process.env.VIDEO_OUTPUT_BUCKET || process.env.GCS_VIDEO_BUCKET;
+  if (!bucket) {
+    console.log('[Cloud Video Job] VIDEO_OUTPUT_BUCKET not set. Skipping Cloud Storage upload.');
+    return;
+  }
+  const prefix = (process.env.VIDEO_OUTPUT_PREFIX || 'seed-videos').replace(/^\/+|\/+$/g, '');
+  const destination = `gs://${bucket}/${prefix}/`;
+  console.log(`[Cloud Video Job] Uploading generated videos and plans to ${destination}`);
+  const files = [];
+  if (fs.existsSync(VIDEOS_DIR)) {
+    for (const name of fs.readdirSync(VIDEOS_DIR)) {
+      if (/\.(mp4|jpg|jpeg|png)$/i.test(name)) files.push(path.join(VIDEOS_DIR, name));
+    }
+  }
+  if (fs.existsSync(PLANS_DIR)) {
+    for (const name of fs.readdirSync(PLANS_DIR)) {
+      if (/\.json$/i.test(name)) files.push(path.join(PLANS_DIR, name));
+    }
+  }
+  if (!files.length) {
+    console.log('[Cloud Video Job] No generated files found to upload.');
+    return;
+  }
+  run('gsutil', ['-m', 'cp', ...files, destination]);
+  if (process.env.MAKE_GCS_VIDEOS_PUBLIC === '1') {
+    run('gsutil', ['-m', 'acl', 'ch', '-r', '-u', 'AllUsers:R', destination]);
+  }
+}
+
+function runSocialPoster() {
+  if (process.env.SKIP_SOCIAL_POSTING === '1') {
+    console.log('[Cloud Video Job] SKIP_SOCIAL_POSTING=1. Skipping social posting.');
+    return;
+  }
+  console.log('[Cloud Video Job] Running social media auto-poster...');
+  run('node', ['scripts/social-media-auto-post.mjs']);
+}
+
+function main() {
+  console.log('[Cloud Video Job] Starting Nature\'s Way Soil video + social pipeline.');
+  hydrateSecrets();
+  console.log('[Cloud Video Job] Generating videos...');
+  run('node', ['scripts/create-quality-seed-videos.mjs', '--all']);
+  uploadOutputsToCloudStorage();
+  runSocialPoster();
+  console.log('[Cloud Video Job] Done.');
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`[Cloud Video Job] Failed: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What changed

- Adds `npm run video:social` to run one Google Cloud pipeline.
- Adds `scripts/cloud-video-social-job.mjs`.
- The Cloud job now:
  - loads platform keys/settings from Google Secret Manager at runtime,
  - generates the five quality seed-style product videos,
  - optionally uploads MP4/JPG/JSON output to Cloud Storage,
  - runs the existing `scripts/social-media-auto-post.mjs` poster.
- Updates `cloud/video-generator/Dockerfile` so the container includes FFmpeg, gcloud, and gsutil.
- Updates `cloud/video-generator/README.md` with deployment, permissions, bucket, and testing switches.

## Notes

- No secrets are committed.
- Secret values are read at runtime using the Cloud Run Job service account.
- `SKIP_SOCIAL_POSTING=1` can be used while testing video generation.
- Instagram Reels still need a publicly accessible video URL, so the website or public Cloud Storage path should serve the final MP4s before Instagram posting is expected to work reliably.