### PR TITLE
Route generated social videos through website URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,10 @@
 /** @type {import('next').NextConfig} */
+const videoPublicBaseUrl = (
+  process.env.VIDEO_PUBLIC_BASE_URL ||
+  process.env.NEXT_PUBLIC_VIDEO_PUBLIC_BASE_URL ||
+  'https://storage.googleapis.com/natureswaysoil-videos/seed-videos'
+).replace(/\/$/, '')
+
 const nextConfig = {
   reactStrictMode: true,
   images: {
@@ -8,6 +14,7 @@ const nextConfig = {
       { protocol: 'https', hostname: 'images.unsplash.com' },
       { protocol: 'https', hostname: 'd3uryq9bhgb5qr.cloudfront.net' },
       { protocol: 'https', hostname: 'cdn.abacus.ai' },
+      { protocol: 'https', hostname: 'storage.googleapis.com' },
     ],
     formats: ['image/webp', 'image/avif']
   },
@@ -16,10 +23,21 @@ const nextConfig = {
       {
         source: '/videos/:path*',
         headers: [
-          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+          { key: 'Access-Control-Allow-Origin', value: '*' }
         ]
       }
     ]
+  },
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: '/videos/:path*',
+          destination: `${videoPublicBaseUrl}/:path*`,
+        },
+      ],
+    }
   },
   async redirects() {
     return [

--- a/scripts/cloud-video-social-job.mjs
+++ b/scripts/cloud-video-social-job.mjs
@@ -6,11 +6,9 @@
  * Pipeline:
  * 1. Hydrate environment variables from Google Secret Manager.
  * 2. Generate the top-five quality seed-style videos.
- * 3. Optionally upload videos/posters/plans to Cloud Storage.
- * 4. Run the existing social-media auto-poster.
- *
- * This script is intentionally conservative: it never hardcodes credentials and it
- * can run with only Secret Manager + platform env vars supplied by Cloud Run Job.
+ * 3. Upload videos/posters/plans to Cloud Storage.
+ * 4. Set social posting video URLs to website URLs.
+ * 5. Run the existing social-media auto-poster.
  */
 
 import fs from 'fs';
@@ -24,9 +22,13 @@ const PROJECT = path.resolve(__dirname, '..');
 const VIDEOS_DIR = path.join(PROJECT, 'public', 'videos');
 const PLANS_DIR = path.join(PROJECT, 'content', 'generated-videos');
 const SECRET_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || process.env.PROJECT_ID;
+const DEFAULT_SITE_URL = 'https://www.natureswaysoil.com';
 const SECRET_NAMES = [
   'PEXELS_API_KEY',
   'NEXT_PUBLIC_SITE_URL',
+  'VIDEO_OUTPUT_BUCKET',
+  'VIDEO_OUTPUT_PREFIX',
+  'VIDEO_PUBLIC_BASE_URL',
   'INSTAGRAM_ACCESS_TOKEN',
   'INSTAGRAM_IG_ID',
   'FACEBOOK_PAGE_ID',
@@ -94,13 +96,20 @@ function hydrateSecrets() {
   console.log(`[Cloud Video Job] Loaded ${loaded} secret value(s).`);
 }
 
+function setWebsiteVideoEnvironment() {
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || DEFAULT_SITE_URL).replace(/\/$/, '');
+  process.env.NEXT_PUBLIC_SITE_URL = siteUrl;
+  process.env.WEBSITE_BASE_URL = siteUrl;
+  process.env.SOCIAL_VIDEO_BASE_URL = `${siteUrl}/videos`;
+  console.log(`[Cloud Video Job] Social video URLs will use website path: ${process.env.SOCIAL_VIDEO_BASE_URL}/{PRODUCT_ID}.mp4`);
+}
+
 function uploadOutputsToCloudStorage() {
-  const bucket = process.env.VIDEO_OUTPUT_BUCKET || process.env.GCS_VIDEO_BUCKET;
-  if (!bucket) {
-    console.log('[Cloud Video Job] VIDEO_OUTPUT_BUCKET not set. Skipping Cloud Storage upload.');
-    return;
-  }
+  const bucket = process.env.VIDEO_OUTPUT_BUCKET || process.env.GCS_VIDEO_BUCKET || 'natureswaysoil-videos';
   const prefix = (process.env.VIDEO_OUTPUT_PREFIX || 'seed-videos').replace(/^\/+|\/+$/g, '');
+  process.env.VIDEO_OUTPUT_BUCKET = bucket;
+  process.env.VIDEO_OUTPUT_PREFIX = prefix;
+
   const destination = `gs://${bucket}/${prefix}/`;
   console.log(`[Cloud Video Job] Uploading generated videos and plans to ${destination}`);
   const files = [];
@@ -118,10 +127,18 @@ function uploadOutputsToCloudStorage() {
     console.log('[Cloud Video Job] No generated files found to upload.');
     return;
   }
+
   run('gsutil', ['-m', 'cp', ...files, destination]);
+  run('gsutil', ['-m', 'setmeta', '-h', 'Cache-Control:public, max-age=31536000, immutable', `${destination}*`]);
+
   if (process.env.MAKE_GCS_VIDEOS_PUBLIC === '1') {
     run('gsutil', ['-m', 'acl', 'ch', '-r', '-u', 'AllUsers:R', destination]);
   }
+
+  const publicBase = (process.env.VIDEO_PUBLIC_BASE_URL || `https://storage.googleapis.com/${bucket}/${prefix}`).replace(/\/$/, '');
+  process.env.VIDEO_PUBLIC_BASE_URL = publicBase;
+  process.env.NEXT_PUBLIC_VIDEO_PUBLIC_BASE_URL = publicBase;
+  console.log(`[Cloud Video Job] Website /videos/* should rewrite to: ${publicBase}/*`);
 }
 
 function runSocialPoster() {
@@ -136,6 +153,7 @@ function runSocialPoster() {
 function main() {
   console.log('[Cloud Video Job] Starting Nature\'s Way Soil video + social pipeline.');
   hydrateSecrets();
+  setWebsiteVideoEnvironment();
   console.log('[Cloud Video Job] Generating videos...');
   run('node', ['scripts/create-quality-seed-videos.mjs', '--all']);
   uploadOutputsToCloudStorage();


### PR DESCRIPTION
## What changed

- Adds a Next.js rewrite so website URLs like `/videos/NWS_014.mp4` route to the Cloud Storage video output.
- Keeps social platforms seeing `https://www.natureswaysoil.com/videos/{PRODUCT_ID}.mp4` instead of raw Google Cloud Storage URLs.
- Adds `VIDEO_PUBLIC_BASE_URL` / `NEXT_PUBLIC_VIDEO_PUBLIC_BASE_URL` support for the storage origin.
- Adds CORS header on `/videos/*` for social platform fetching.
- Updates the Cloud video/social job to set `SOCIAL_VIDEO_BASE_URL` to the website `/videos` path before running the social poster.
- Defaults output to `gs://natureswaysoil-videos/seed-videos/` and website rewrite origin to `https://storage.googleapis.com/natureswaysoil-videos/seed-videos`.

## Result

After deployment and Cloud Run job execution, social media video URLs should go through the website:

```text
https://www.natureswaysoil.com/videos/NWS_014.mp4
```

The website proxies/rewrites that path to Cloud Storage behind the scenes.