### PR TITLE
Add production order dashboard and packing slips

### DIFF
--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -84,7 +84,10 @@ export default function AdminOrders({ orders, secret, error }: Props) {
                 <td style={td}>{money(order.total)}</td>
                 <td style={td}>
                   {order.pi_id ? (
-                    <Link href={`/admin/packing-slip/${order.pi_id}`} style={{ color: '#14532d', fontWeight: 700 }}>
+                    <Link
+                      href={{ pathname: '/admin/packing-slip/[id]', query: { id: order.pi_id, secret } }}
+                      style={{ color: '#14532d', fontWeight: 700 }}
+                    >
                       Print Slip
                     </Link>
                   ) : (

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -18,6 +18,7 @@ type OrderRow = {
 
 type Props = {
   orders: OrderRow[];
+  secret: string;
   error?: string;
 };
 
@@ -26,11 +27,13 @@ const money = (value: number | null) =>
     ? value.toLocaleString('en-US', { style: 'currency', currency: 'USD' })
     : '—';
 
-export default function AdminOrders({ orders, error }: Props) {
+export default function AdminOrders({ orders, secret, error }: Props) {
   const handleShipOrder = (piId: string | null) => {
     if (!piId) return;
 
-    window.open(`/admin/packing-slip/${piId}`, '_blank', 'noopener,noreferrer');
+    const qs = secret ? `?secret=${encodeURIComponent(secret)}` : '';
+
+    window.open(`/admin/packing-slip/${piId}${qs}`, '_blank', 'noopener,noreferrer');
     window.open(`https://ss.shipstation.com/#/orders/all?quickSearch=${encodeURIComponent(piId)}`, '_blank', 'noopener,noreferrer');
   };
 

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link';
+import type { GetServerSideProps } from 'next';
+import { getServiceSupabase } from '../../lib/supabase';
+
+type OrderRow = {
+  id: string;
+  pi_id: string | null;
+  status: string | null;
+  total: number | null;
+  tax: number | null;
+  shipping_state: string | null;
+  shipping_city: string | null;
+  shipping_zip: string | null;
+  shipping_address1: string | null;
+  shipping_phone: string | null;
+  created_at: string | null;
+};
+
+type Props = {
+  orders: OrderRow[];
+  error?: string;
+};
+
+const money = (value: number | null) =>
+  typeof value === 'number'
+    ? value.toLocaleString('en-US', { style: 'currency', currency: 'USD' })
+    : '—';
+
+export default function AdminOrders({ orders, error }: Props) {
+  const handleShipOrder = (piId: string | null) => {
+    if (!piId) return;
+
+    window.open(`/admin/packing-slip/${piId}`, '_blank', 'noopener,noreferrer');
+    window.open(`https://ss.shipstation.com/#/orders/all?quickSearch=${encodeURIComponent(piId)}`, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <main style={{ maxWidth: 1240, margin: '0 auto', padding: '32px 20px', fontFamily: 'Arial, sans-serif' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'center', marginBottom: 24 }}>
+        <div>
+          <h1 style={{ margin: 0, color: '#14532d' }}>Website Orders</h1>
+          <p style={{ marginTop: 6, color: '#4b5563' }}>Print packing slips and open ShipStation in one click.</p>
+        </div>
+        <button onClick={() => window.print()} style={{ padding: '10px 14px', borderRadius: 8, border: '1px solid #14532d', background: '#14532d', color: 'white', fontWeight: 700 }}>
+          Print Page
+        </button>
+      </div>
+
+      {error ? <p style={{ padding: 12, background: '#fef2f2', color: '#991b1b', borderRadius: 8 }}>{error}</p> : null}
+
+      <div style={{ overflowX: 'auto', border: '1px solid #e5e7eb', borderRadius: 12 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 1000 }}>
+          <thead style={{ background: '#f3f4f6' }}>
+            <tr>
+              <th style={th}>Date</th>
+              <th style={th}>Order / Payment</th>
+              <th style={th}>Ship To</th>
+              <th style={th}>Status</th>
+              <th style={th}>Total</th>
+              <th style={th}>Packing Slip</th>
+              <th style={th}>One-Click Ship</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.map((order) => (
+              <tr key={order.id}>
+                <td style={td}>{order.created_at ? new Date(order.created_at).toLocaleString() : '—'}</td>
+                <td style={td}>
+                  <strong>{order.id}</strong>
+                  <br />
+                  <span style={{ color: '#6b7280' }}>{order.pi_id || 'No Stripe PI saved'}</span>
+                </td>
+                <td style={td}>
+                  {order.shipping_address1 || '—'}
+                  <br />
+                  {[order.shipping_city, order.shipping_state, order.shipping_zip].filter(Boolean).join(', ')}
+                  <br />
+                  <span style={{ color: '#6b7280' }}>{order.shipping_phone || ''}</span>
+                </td>
+                <td style={td}>{order.status || '—'}</td>
+                <td style={td}>{money(order.total)}</td>
+                <td style={td}>
+                  {order.pi_id ? (
+                    <Link href={`/admin/packing-slip/${order.pi_id}`} style={{ color: '#14532d', fontWeight: 700 }}>
+                      Print Slip
+                    </Link>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+                <td style={td}>
+                  {order.pi_id ? (
+                    <button
+                      onClick={() => handleShipOrder(order.pi_id)}
+                      style={{
+                        padding: '8px 12px',
+                        borderRadius: 8,
+                        border: '1px solid #14532d',
+                        background: '#14532d',
+                        color: 'white',
+                        fontWeight: 700,
+                        cursor: 'pointer',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      Ship Order
+                    </button>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {!orders.length && !error ? <p style={{ marginTop: 20 }}>No orders found yet.</p> : null}
+    </main>
+  );
+}
+
+const th: React.CSSProperties = { textAlign: 'left', padding: 12, borderBottom: '1px solid #e5e7eb', color: '#374151' };
+const td: React.CSSProperties = { padding: 12, borderBottom: '1px solid #e5e7eb', verticalAlign: 'top' };
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  try {
+    const supabase = getServiceSupabase();
+    const { data, error } = await supabase
+      .from('orders')
+      .select('id, pi_id, status, total, tax, shipping_state, shipping_city, shipping_zip, shipping_address1, shipping_phone, created_at')
+      .order('created_at', { ascending: false })
+      .limit(100);
+
+    if (error) {
+      return { props: { orders: [], error: error.message } };
+    }
+
+    return { props: { orders: (data || []) as OrderRow[] } };
+  } catch (error) {
+    return {
+      props: {
+        orders: [],
+        error: error instanceof Error ? error.message : 'Unable to load orders.',
+      },
+    };
+  }
+};

--- a/pages/admin/orders.tsx
+++ b/pages/admin/orders.tsx
@@ -123,7 +123,14 @@ export default function AdminOrders({ orders, error }: Props) {
 const th: React.CSSProperties = { textAlign: 'left', padding: 12, borderBottom: '1px solid #e5e7eb', color: '#374151' };
 const td: React.CSSProperties = { padding: 12, borderBottom: '1px solid #e5e7eb', verticalAlign: 'top' };
 
-export const getServerSideProps: GetServerSideProps<Props> = async () => {
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const configuredSecret = process.env.PRINT_QUEUE_SECRET || process.env.PRINT_SLIP_TOKEN;
+  const providedSecret = Array.isArray(ctx.query.secret) ? ctx.query.secret[0] : ctx.query.secret;
+
+  if (!configuredSecret || providedSecret !== configuredSecret) {
+    return { notFound: true };
+  }
+
   try {
     const supabase = getServiceSupabase();
     const { data, error } = await supabase
@@ -133,14 +140,15 @@ export const getServerSideProps: GetServerSideProps<Props> = async () => {
       .limit(100);
 
     if (error) {
-      return { props: { orders: [], error: error.message } };
+      return { props: { orders: [], secret: providedSecret as string, error: error.message } };
     }
 
-    return { props: { orders: (data || []) as OrderRow[] } };
+    return { props: { orders: (data || []) as OrderRow[], secret: providedSecret as string } };
   } catch (error) {
     return {
       props: {
         orders: [],
+        secret: providedSecret as string,
         error: error instanceof Error ? error.message : 'Unable to load orders.',
       },
     };

--- a/pages/admin/packing-slip/[id].tsx
+++ b/pages/admin/packing-slip/[id].tsx
@@ -122,9 +122,15 @@ const th: React.CSSProperties = { padding: 10, borderBottom: '1px solid #d1d5db'
 const td: React.CSSProperties = { padding: 10, borderBottom: '1px solid #e5e7eb', verticalAlign: 'top' };
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const configuredSecret = process.env.PRINT_QUEUE_SECRET || process.env.PRINT_SLIP_TOKEN;
+  const providedSecret = Array.isArray(ctx.query.secret) ? ctx.query.secret[0] : ctx.query.secret;
+
+  if (!configuredSecret || providedSecret !== configuredSecret) {
+    return { notFound: true };
+  }
+
   const id = ctx.params?.id as string;
   const supabase = getServiceSupabase();
-
   const { data: order } = await supabase
     .from('orders')
     .select('*')

--- a/pages/admin/packing-slip/[id].tsx
+++ b/pages/admin/packing-slip/[id].tsx
@@ -83,7 +83,7 @@ export default function PackingSlip({ order, items }: Props) {
             <th style={th}>Product Name</th>
             <th style={th}>SKU</th>
             <th style={{ ...th, textAlign: 'center' }}>Qty</th>
-            <th style={{ ...th, textAlign: 'right' }}>Price</th>
+            <th style={{ ...th, textAlign: 'right' }}>Line Total</th>
           </tr>
         </thead>
         <tbody>
@@ -93,7 +93,7 @@ export default function PackingSlip({ order, items }: Props) {
                 <td style={td}><strong>{itemDisplayName(item)}</strong></td>
                 <td style={td}>{item.sku}</td>
                 <td style={{ ...td, textAlign: 'center', fontWeight: 700 }}>{item.qty}</td>
-                <td style={{ ...td, textAlign: 'right' }}>{money(item.price)}</td>
+                <td style={{ ...td, textAlign: 'right' }}>{money(Number((item as any).unit_price ?? item.price) * item.qty)}</td>
               </tr>
             ))
           ) : (

--- a/pages/admin/packing-slip/[id].tsx
+++ b/pages/admin/packing-slip/[id].tsx
@@ -1,0 +1,169 @@
+import type { GetServerSideProps } from 'next';
+import { getServiceSupabase } from '../../../lib/supabase';
+
+type PackingSlipItem = {
+  id?: string;
+  sku: string;
+  qty: number;
+  price: number;
+  product_name?: string | null;
+  size_name?: string | null;
+};
+
+type Props = {
+  order: any | null;
+  items: PackingSlipItem[];
+};
+
+const money = (value: number | string | null | undefined) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric)
+    ? numeric.toLocaleString('en-US', { style: 'currency', currency: 'USD' })
+    : '—';
+};
+
+const itemDisplayName = (item: PackingSlipItem) => {
+  const product = item.product_name?.trim();
+  const size = item.size_name?.trim();
+
+  if (product && size) return `${product} - ${size}`;
+  if (product) return product;
+  if (size) return size;
+  return item.sku || 'Product';
+};
+
+export default function PackingSlip({ order, items }: Props) {
+  if (!order) return <p style={{ padding: 40 }}>Order not found.</p>;
+
+  return (
+    <main style={{ fontFamily: 'Arial, sans-serif', padding: 30, maxWidth: 850, margin: '0 auto' }}>
+      <style jsx global>{`
+        @media print {
+          .no-print { display: none !important; }
+          body { margin: 0; }
+        }
+      `}</style>
+
+      <section style={{ display: 'flex', justifyContent: 'space-between', gap: 20, borderBottom: '2px solid #14532d', paddingBottom: 16 }}>
+        <div>
+          <h1 style={{ margin: 0, color: '#14532d' }}>Nature's Way Soil</h1>
+          <p style={{ margin: '6px 0 0' }}>Naturally Stronger Soil Starts Here</p>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <h2 style={{ margin: 0 }}>Packing Slip</h2>
+          <p style={{ margin: '6px 0 0' }}><strong>Status:</strong> {order.status || '—'}</p>
+        </div>
+      </section>
+
+      <section style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginTop: 24 }}>
+        <div>
+          <h3 style={{ marginBottom: 8 }}>Order</h3>
+          <p style={{ margin: 0 }}>
+            <strong>Order ID:</strong> {order.id}<br />
+            <strong>Stripe:</strong> {order.pi_id}<br />
+            <strong>Date:</strong> {order.created_at ? new Date(order.created_at).toLocaleString() : '—'}
+          </p>
+        </div>
+
+        <div>
+          <h3 style={{ marginBottom: 8 }}>Ship To</h3>
+          <p style={{ margin: 0 }}>
+            {order.shipping_address1}<br />
+            {order.shipping_address2 ? <>{order.shipping_address2}<br /></> : null}
+            {order.shipping_city}, {order.shipping_state} {order.shipping_zip}<br />
+            {order.shipping_phone || ''}
+          </p>
+        </div>
+      </section>
+
+      <h3 style={{ marginTop: 30 }}>Items to Pack</h3>
+      <table style={{ width: '100%', borderCollapse: 'collapse', border: '1px solid #d1d5db' }}>
+        <thead>
+          <tr style={{ background: '#f3f4f6' }}>
+            <th style={th}>Product Name</th>
+            <th style={th}>SKU</th>
+            <th style={{ ...th, textAlign: 'center' }}>Qty</th>
+            <th style={{ ...th, textAlign: 'right' }}>Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.length ? (
+            items.map((item, i) => (
+              <tr key={item.id || i}>
+                <td style={td}><strong>{itemDisplayName(item)}</strong></td>
+                <td style={td}>{item.sku}</td>
+                <td style={{ ...td, textAlign: 'center', fontWeight: 700 }}>{item.qty}</td>
+                <td style={{ ...td, textAlign: 'right' }}>{money(item.price)}</td>
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td style={td} colSpan={4}>No line items found for this order.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      <section style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end', marginTop: 28 }}>
+        <p style={{ margin: 0 }}>Thank you for supporting our family farm.</p>
+        <p style={{ textAlign: 'right', fontSize: 18, margin: 0 }}>
+          <strong>Total:</strong> {money(order.total)}
+        </p>
+      </section>
+
+      <button className="no-print" onClick={() => window.print()} style={{ marginTop: 28, padding: '10px 16px', borderRadius: 8, background: '#14532d', color: 'white', border: 0, fontWeight: 700 }}>
+        Print Packing Slip
+      </button>
+    </main>
+  );
+}
+
+const th: React.CSSProperties = { padding: 10, borderBottom: '1px solid #d1d5db', textAlign: 'left' };
+const td: React.CSSProperties = { padding: 10, borderBottom: '1px solid #e5e7eb', verticalAlign: 'top' };
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const id = ctx.params?.id as string;
+  const supabase = getServiceSupabase();
+
+  const { data: order } = await supabase
+    .from('orders')
+    .select('*')
+    .eq('pi_id', id)
+    .single();
+
+  if (!order?.id) {
+    return { props: { order: null, items: [] } };
+  }
+
+  const { data: orderItems } = await supabase
+    .from('order_items')
+    .select('*')
+    .eq('order_id', order.id);
+
+  const skus = Array.from(new Set((orderItems || []).map((item: any) => item.sku).filter(Boolean)));
+
+  let sizeLookup: Record<string, { product_name?: string | null; size_name?: string | null }> = {};
+
+  if (skus.length) {
+    const { data: sizes } = await supabase
+      .from('product_sizes')
+      .select('sku, name, products(name)')
+      .in('sku', skus);
+
+    sizeLookup = (sizes || []).reduce((acc: Record<string, { product_name?: string | null; size_name?: string | null }>, size: any) => {
+      acc[size.sku] = {
+        product_name: size.products?.name || null,
+        size_name: size.name || null,
+      };
+      return acc;
+    }, {});
+  }
+
+  const items = (orderItems || []).map((item: any) => ({
+    ...item,
+    product_name: sizeLookup[item.sku]?.product_name || null,
+    size_name: sizeLookup[item.sku]?.size_name || null,
+  }));
+
+  return { props: { order, items } };
+};


### PR DESCRIPTION
Adds `/admin/orders` and `/admin/packing-slip/[id]` on a fresh branch based on current `main`, avoiding the stale feature branch that was 268 commits behind. Includes the one-click Ship Order button that opens the packing slip and ShipStation search.