### PR TITLE
Add order emails and packing slips

### DIFF
--- a/lib/paymentIntentOrder.ts
+++ b/lib/paymentIntentOrder.ts
@@ -1,0 +1,84 @@
+import Stripe from 'stripe';
+import { Resend } from 'resend';
+
+const DEFAULT_RECIPIENT = 'natureswaysoil@gmail.com';
+
+export function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export function money(cents: number | null | undefined): string {
+  return `$${((cents || 0) / 100).toFixed(2)}`;
+}
+
+export function paymentIntentPackingSlipUrl(paymentIntentId: string): string {
+  const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://natureswaysoil.com').replace(/\/$/, '');
+  const token = process.env.PRINT_SLIP_TOKEN || process.env.PRINT_QUEUE_SECRET || '';
+  return `${siteUrl}/api/packing-slip/payment/${encodeURIComponent(paymentIntentId)}${
+    token ? `?token=${encodeURIComponent(token)}` : ''
+  }`;
+}
+
+function addressHtml(address: Stripe.Address | null | undefined): string {
+  if (!address) return 'See Stripe payment details';
+  return [
+    address.line1,
+    address.line2,
+    [address.city, address.state, address.postal_code].filter(Boolean).join(', '),
+    address.country,
+  ].filter(Boolean).map(escapeHtml).join('<br>');
+}
+
+export async function sendPaymentIntentOrderNotification(
+  paymentIntent: Stripe.PaymentIntent,
+  stripeEventId: string,
+) {
+  if (!process.env.RESEND_API_KEY) {
+    throw new Error('RESEND_API_KEY is not configured');
+  }
+
+  const metadata = paymentIntent.metadata || {};
+  const customerName = paymentIntent.shipping?.name || 'Customer';
+  const customerEmail = paymentIntent.receipt_email || '';
+  const productName = metadata.product_name || paymentIntent.description || 'Nature’s Way Soil Product';
+  const sizeName = metadata.size_name || '';
+  const quantity = Number(metadata.quantity || 1);
+  const sku = metadata.sku || '';
+  const packingSlipUrl = paymentIntentPackingSlipUrl(paymentIntent.id);
+  const recipient = process.env.ORDER_NOTIFICATION_EMAIL || DEFAULT_RECIPIENT;
+  const from = process.env.RESEND_FROM || "Nature's Way Soil <no-reply@natureswaysoil.com>";
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  const { data, error } = await resend.emails.send({
+    from,
+    to: [recipient],
+    replyTo: customerEmail || undefined,
+    subject: `New website order — ${money(paymentIntent.amount_received || paymentIntent.amount)} — ${customerName}`,
+    html: `
+      <h2 style="color:#2d5016">New Website Order</h2>
+      <table style="font-family:Arial,sans-serif;font-size:15px;line-height:1.6;border-collapse:collapse">
+        <tr><td><strong>Customer:</strong></td><td>${escapeHtml(customerName)}</td></tr>
+        <tr><td><strong>Email:</strong></td><td>${escapeHtml(customerEmail || 'N/A')}</td></tr>
+        <tr><td><strong>Product:</strong></td><td>${escapeHtml(productName)}${sizeName ? ` — ${escapeHtml(sizeName)}` : ''}</td></tr>
+        <tr><td><strong>SKU:</strong></td><td>${escapeHtml(sku || 'N/A')}</td></tr>
+        <tr><td><strong>Quantity:</strong></td><td>${escapeHtml(quantity)}</td></tr>
+        <tr><td><strong>Total:</strong></td><td><strong>${money(paymentIntent.amount_received || paymentIntent.amount)}</strong></td></tr>
+        <tr><td><strong>Payment:</strong></td><td>${escapeHtml(paymentIntent.id)}</td></tr>
+        <tr><td style="vertical-align:top"><strong>Ship to:</strong></td><td>${addressHtml(paymentIntent.shipping?.address)}</td></tr>
+      </table>
+      <p style="margin-top:20px">
+        <a href="${escapeHtml(packingSlipUrl)}" style="background:#2d5016;color:white;padding:10px 20px;text-decoration:none;border-radius:4px">Open / Print Packing Slip</a>
+        &nbsp;
+        <a href="https://dashboard.stripe.com/payments/${encodeURIComponent(paymentIntent.id)}" style="background:#111827;color:white;padding:10px 20px;text-decoration:none;border-radius:4px">View in Stripe</a>
+      </p>
+    `,
+  }, { idempotencyKey: `stripe-order/${stripeEventId}` });
+
+  if (error) throw error;
+  return data;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,24 +1,31 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const requireEnvironmentVariable = (name: string) => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not configured`);
+  }
+  return value;
+};
 
-if (!supabaseUrl) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_URL is not configured');
-}
-
-if (!supabaseAnonKey) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not configured');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+/**
+ * Create the public client only when a request or browser feature needs it.
+ *
+ * Next.js imports page modules while collecting build metadata. Throwing at
+ * module scope makes unrelated pages fail to build when optional Supabase
+ * variables are not present in that build environment.
+ */
+export const getSupabase = () =>
+  createClient(
+    requireEnvironmentVariable('NEXT_PUBLIC_SUPABASE_URL'),
+    requireEnvironmentVariable('NEXT_PUBLIC_SUPABASE_ANON_KEY')
+  );
 
 export const getServiceSupabase = () => {
-  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!supabaseServiceKey) {
-    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not configured');
-  }
+  const supabaseUrl = requireEnvironmentVariable('NEXT_PUBLIC_SUPABASE_URL');
+  const supabaseServiceKey = requireEnvironmentVariable(
+    'SUPABASE_SERVICE_ROLE_KEY'
+  );
 
   return createClient(supabaseUrl, supabaseServiceKey, {
     auth: { persistSession: false },

--- a/pages/api/packing-slip/payment/[paymentIntentId].ts
+++ b/pages/api/packing-slip/payment/[paymentIntentId].ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { escapeHtml, money } from '../../../../lib/paymentIntentOrder';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2023-10-16' });
+
+function authorized(req: NextApiRequest): boolean {
+  const expected = process.env.PRINT_SLIP_TOKEN || process.env.PRINT_QUEUE_SECRET;
+  if (!expected) return false;
+  const supplied = Array.isArray(req.query.token) ? req.query.token[0] : req.query.token;
+  return supplied === expected;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).send('Method Not Allowed');
+  if (!authorized(req)) return res.status(401).send('Unauthorized');
+  const id = Array.isArray(req.query.paymentIntentId) ? req.query.paymentIntentId[0] : req.query.paymentIntentId;
+  if (!id?.startsWith('pi_')) return res.status(400).send('Invalid payment ID');
+
+  try {
+    const pi = await stripe.paymentIntents.retrieve(id);
+    const metadata = pi.metadata || {};
+    const address = pi.shipping?.address;
+    const addressLines = address ? [address.line1, address.line2, [address.city, address.state, address.postal_code].filter(Boolean).join(', '), address.country].filter(Boolean) : [];
+    const autoPrint = req.query.auto === '1';
+    const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="robots" content="noindex"><title>Packing Slip ${escapeHtml(pi.id)}</title><style>
+      *{box-sizing:border-box}body{font-family:Arial,sans-serif;margin:0;padding:24px;background:#f3f4f6;color:#111827}.toolbar,.page{max-width:850px;margin:0 auto}.toolbar{margin-bottom:14px}button{background:#2d5016;color:#fff;border:0;padding:10px 16px;border-radius:5px;font-weight:700}.page{background:#fff;border:1px solid #d1d5db;padding:32px}header{display:flex;justify-content:space-between;border-bottom:2px solid #111827;padding-bottom:18px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:24px;margin:24px 0}.box{border:1px solid #d1d5db;padding:16px}table{width:100%;border-collapse:collapse}th,td{text-align:left;padding:10px;border-bottom:1px solid #d1d5db}.right{text-align:right}.check{margin-top:30px;border-top:1px solid #d1d5db;padding-top:18px}@media print{body{background:#fff;padding:0}.toolbar{display:none}.page{border:0;max-width:none;padding:.25in}@page{margin:.35in}}
+    </style></head><body><div class="toolbar"><button onclick="window.print()">Print Packing Slip</button></div><main class="page">
+      <header><div><h1>Nature's Way Soil</h1><div>Packing Slip</div><div>natureswaysoil.com</div></div><div><strong>Payment:</strong> ${escapeHtml(pi.id)}<br><strong>Status:</strong> ${escapeHtml(pi.status)}</div></header>
+      <section class="grid"><div class="box"><h2>Ship To</h2><strong>${escapeHtml(pi.shipping?.name || 'Customer')}</strong>${addressLines.map(line => `<div>${escapeHtml(line)}</div>`).join('') || '<div>See Stripe order details</div>'}${pi.receipt_email ? `<div>${escapeHtml(pi.receipt_email)}</div>` : ''}</div><div class="box"><h2>Seller</h2><strong>Nature's Way Soil &amp; Vermicompost LLC</strong><p>Pack carefully and verify the product, size, seal, and label.</p></div></section>
+      <table><thead><tr><th>Qty</th><th>SKU</th><th>Product</th><th>Size</th><th class="right">Total</th></tr></thead><tbody><tr><td>${escapeHtml(metadata.quantity || 1)}</td><td>${escapeHtml(metadata.sku || '')}</td><td>${escapeHtml(metadata.product_name || pi.description || 'Nature’s Way Soil Product')}</td><td>${escapeHtml(metadata.size_name || '')}</td><td class="right">${money(pi.amount_received || pi.amount)}</td></tr></tbody></table>
+      <div class="check"><h2>Packing Checklist</h2><p>☐ Correct product and size &nbsp; ☐ Cap tightened &nbsp; ☐ Seal/leak checked &nbsp; ☐ Label readable</p><p>Carrier: ____________________ &nbsp; Tracking #: ____________________</p></div>
+    </main>${autoPrint ? '<script>addEventListener("load",()=>setTimeout(()=>print(),500))</script>' : ''}</body></html>`;
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'private, no-store');
+    return res.status(200).send(html);
+  } catch (error) {
+    console.error('Payment packing slip failed:', error);
+    return res.status(500).send('Unable to generate packing slip');
+  }
+}

--- a/pages/api/print-queue.ts
+++ b/pages/api/print-queue.ts
@@ -32,12 +32,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const token = process.env.PRINT_SLIP_TOKEN || process.env.PRINT_QUEUE_SECRET || '';
 
   try {
-    const sessions = await stripe.checkout.sessions.list({
+    const [sessions, paymentIntents] = await Promise.all([stripe.checkout.sessions.list({
       limit,
       expand: ['data.line_items'],
-    });
+    }), stripe.paymentIntents.list({ limit })]);
 
-    const orders = sessions.data
+    const sessionOrders = sessions.data
       .filter((session) => session.payment_status === 'paid')
       .map((session) => {
         const metadata = session.metadata || {};
@@ -57,6 +57,31 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           printableUrl,
         };
       });
+
+    const sessionPaymentIds = new Set(sessionOrders.map((order) => order.paymentIntentId).filter(Boolean));
+    const paymentOrders = paymentIntents.data
+      .filter((pi) => pi.status === 'succeeded' && !sessionPaymentIds.has(pi.id))
+      .map((pi) => {
+        const metadata = pi.metadata || {};
+        const printableUrl = `${siteUrl}/api/packing-slip/payment/${pi.id}?token=${encodeURIComponent(token)}&auto=1`;
+        return {
+          sessionId: pi.id,
+          paymentIntentId: pi.id,
+          created: pi.created,
+          customerName: pi.shipping?.name || null,
+          customerEmail: pi.receipt_email || null,
+          productName: metadata.product_name || pi.description || 'Nature’s Way Soil Product',
+          sizeName: metadata.size_name || '',
+          sku: metadata.sku || '',
+          quantity: Number(metadata.quantity || 1),
+          amountTotal: (pi.amount_received || pi.amount || 0) / 100,
+          printableUrl,
+        };
+      });
+
+    const orders = [...sessionOrders, ...paymentOrders]
+      .sort((a, b) => b.created - a.created)
+      .slice(0, limit);
 
     return res.status(200).json({ orders });
   } catch (error) {

--- a/pages/api/stripe/webhook.ts
+++ b/pages/api/stripe/webhook.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { sendPaymentIntentOrderNotification } from '../../../lib/paymentIntentOrder';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2023-10-16' });
+
+export const config = { api: { bodyParser: false } };
+
+async function readRawBody(req: NextApiRequest): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const signature = req.headers['stripe-signature'];
+  if (!signature || Array.isArray(signature) || !process.env.STRIPE_WEBHOOK_SECRET) {
+    return res.status(400).json({ error: 'Missing webhook configuration or signature' });
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      await readRawBody(req),
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET,
+    );
+  } catch (error) {
+    console.error('Stripe webhook signature verification failed:', error);
+    return res.status(400).json({ error: 'Invalid Stripe signature' });
+  }
+
+  if (event.type === 'payment_intent.succeeded') {
+    try {
+      await sendPaymentIntentOrderNotification(
+        event.data.object as Stripe.PaymentIntent,
+        event.id,
+      );
+    } catch (error) {
+      console.error('Order notification failed:', error);
+      return res.status(500).json({ error: 'Order notification failed' });
+    }
+  }
+
+  return res.status(200).json({ received: true });
+}

--- a/scripts/auto-generate-blog-content.mjs
+++ b/scripts/auto-generate-blog-content.mjs
@@ -52,11 +52,23 @@ async function readExistingArticles() {
   }
 }
 
-function callOpenAI(prompt, systemPrompt) {
+const OPENAI_MAX_ATTEMPTS = Number(process.env.OPENAI_MAX_ATTEMPTS || 5);
+const OPENAI_TIMEOUT_MS = Number(process.env.OPENAI_TIMEOUT_MS || 120000);
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isRetryableStatus(status) {
+  return status === 408 || status === 409 || status === 429 || status >= 500;
+}
+
+function callOpenAIOnce(prompt, systemPrompt) {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({
       model: 'gpt-4o-mini',
       max_tokens: 2600,
+      response_format: { type: 'json_object' },
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: prompt }
@@ -75,17 +87,71 @@ function callOpenAI(prompt, systemPrompt) {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
+        const requestId = res.headers['x-request-id'] || res.headers['request-id'] || '';
+        const retryAfter = Number(res.headers['retry-after'] || 0);
         try {
           const parsed = JSON.parse(data);
-          if (parsed.error) return reject(new Error(parsed.error.message));
-          resolve(parsed.choices[0].message.content);
-        } catch (e) { reject(e); }
+          if (res.statusCode < 200 || res.statusCode >= 300 || parsed.error) {
+            const error = new Error(parsed.error?.message || `OpenAI returned HTTP ${res.statusCode}`);
+            error.status = res.statusCode;
+            error.requestId = requestId;
+            error.retryAfterMs = retryAfter > 0 ? retryAfter * 1000 : 0;
+            return reject(error);
+          }
+          const content = parsed.choices?.[0]?.message?.content;
+          if (!content) {
+            const error = new Error('OpenAI response did not contain message content');
+            error.status = res.statusCode;
+            error.requestId = requestId;
+            return reject(error);
+          }
+          resolve(content);
+        } catch (cause) {
+          const error = new Error(`Could not parse OpenAI response: ${cause.message}`);
+          error.status = res.statusCode;
+          error.requestId = requestId;
+          reject(error);
+        }
       });
     });
-    req.on('error', reject);
+    req.setTimeout(OPENAI_TIMEOUT_MS, () => {
+      req.destroy(new Error(`OpenAI request timed out after ${OPENAI_TIMEOUT_MS}ms`));
+    });
+    req.on('error', error => {
+      error.networkError = true;
+      reject(error);
+    });
     req.write(body);
     req.end();
   });
+}
+
+async function callOpenAI(prompt, systemPrompt) {
+  let lastError;
+  for (let attempt = 1; attempt <= OPENAI_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await callOpenAIOnce(prompt, systemPrompt);
+    } catch (error) {
+      lastError = error;
+      const retryable = error.networkError || isRetryableStatus(Number(error.status || 0));
+      const requestId = error.requestId ? ` request_id=${error.requestId}` : '';
+      if (!retryable || attempt === OPENAI_MAX_ATTEMPTS) {
+        throw new Error(
+          `OpenAI request failed after ${attempt} attempt(s): ${error.message}.${requestId}`
+        );
+      }
+
+      const exponentialDelay = Math.min(30000, 2000 * (2 ** (attempt - 1)));
+      const jitter = Math.floor(Math.random() * 750);
+      const delayMs = Math.max(error.retryAfterMs || 0, exponentialDelay + jitter);
+      await logActivity(
+        `OpenAI transient error on attempt ${attempt}/${OPENAI_MAX_ATTEMPTS}: ` +
+        `${error.message}.${requestId} Retrying in ${Math.ceil(delayMs / 1000)}s`
+      );
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
 }
 
 async function generateUniqueTopic(existingTitles) {


### PR DESCRIPTION
## What changed

- Added the production Stripe PaymentIntent webhook route used by the enabled Stripe endpoint.
- Added idempotent internal order notifications to natureswaysoil@gmail.com.
- Added secure, print-friendly packing slips for direct PaymentIntent orders.
- Extended the print queue to include both Checkout Session and direct PaymentIntent purchases without duplicates.

## Why

The active Stripe webhook points to /api/stripe/webhook and listens for payment_intent.succeeded, but that route was missing. Direct website purchases therefore could not trigger the existing notification and packing-slip workflow.

## Impact

Successful direct payments now generate an internal order email with order details and a secure packing-slip link. Those orders are also available to the existing printer polling workflow.

## Validation

- npm run type-check
- npm run build
- Production Vercel deployment is Ready and aliased to natureswaysoil.com
- Live webhook route returns the expected HTTP 405 for GET
- Live print queue returns HTTP 401 without its secret