### PR TITLE
Fix seed social posting credentials and failures

### DIFF
--- a/scripts/run-seed-rotation.mjs
+++ b/scripts/run-seed-rotation.mjs
@@ -7,7 +7,12 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT = path.resolve(__dirname, '..');
-const SECRET_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || process.env.PROJECT_ID;
+const SECRET_PROJECT_ID =
+  process.env.SECRET_PROJECT_ID ||
+  process.env.GOOGLE_CLOUD_PROJECT ||
+  process.env.GCLOUD_PROJECT ||
+  process.env.GCP_PROJECT ||
+  process.env.PROJECT_ID;
 const SECRET_NAMES = [
   'PEXELS_API_KEY',
   'NEXT_PUBLIC_SITE_URL',
@@ -53,6 +58,47 @@ function capture(command, args) {
   return result.status === 0 ? result.stdout.trim() : '';
 }
 
+async function metadataAccessToken() {
+  try {
+    const response = await fetch(
+      'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+      { headers: { 'Metadata-Flavor': 'Google' }, signal: AbortSignal.timeout(5000) }
+    );
+    if (!response.ok) return '';
+    const payload = await response.json();
+    return payload.access_token || '';
+  } catch {
+    return '';
+  }
+}
+
+async function accessSecret(secretName, accessToken) {
+  if (accessToken && SECRET_PROJECT_ID) {
+    try {
+      const resource = `projects/${SECRET_PROJECT_ID}/secrets/${secretName}/versions/latest`;
+      const response = await fetch(
+        `https://secretmanager.googleapis.com/v1/${resource}:access`,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          signal: AbortSignal.timeout(10000)
+        }
+      );
+      if (response.ok) {
+        const payload = await response.json();
+        return Buffer.from(payload.payload?.data || '', 'base64').toString('utf8').trim();
+      }
+    } catch {
+      // Local development can still use the gcloud CLI fallback below.
+    }
+  }
+
+  return capture('gcloud', [
+    'secrets', 'versions', 'access', 'latest',
+    '--secret', secretName,
+    '--project', SECRET_PROJECT_ID
+  ]);
+}
+
 function secretNames() {
   const extra = String(process.env.GOOGLE_SECRET_NAMES || '')
     .split(',')
@@ -61,16 +107,17 @@ function secretNames() {
   return [...new Set([...SECRET_NAMES, ...extra])];
 }
 
-function hydrateSecrets() {
+async function hydrateSecrets() {
   if (!SECRET_PROJECT_ID) {
     console.log('[Seed Rotation Entry] No Google Cloud project id found. Using existing env only.');
     return;
   }
 
+  const accessToken = await metadataAccessToken();
   let loaded = 0;
   for (const name of secretNames()) {
     if (process.env[name]) continue;
-    const value = capture('gcloud', ['secrets', 'versions', 'access', 'latest', '--secret', name, '--project', SECRET_PROJECT_ID]);
+    const value = await accessSecret(name, accessToken);
     if (value) {
       process.env[name] = value;
       loaded += 1;
@@ -80,7 +127,7 @@ function hydrateSecrets() {
 }
 
 try {
-  hydrateSecrets();
+  await hydrateSecrets();
   console.log('[Seed Rotation Entry] Build/upload phase...');
   run(['scripts/cloud-video-social-job.mjs'], { ...process.env, SKIP_SOCIAL_POSTING: '1' });
   console.log('[Seed Rotation Entry] Rotation post phase...');

--- a/scripts/social-media-auto-post.mjs
+++ b/scripts/social-media-auto-post.mjs
@@ -34,6 +34,34 @@ const PRODUCTS_FILE = path.join(PROJECT, 'data', 'products.ts');
 const SHEET_PRODUCTS_FILE = path.join(PROJECT, 'content', 'video-scripts', 'sheet-products.json');
 const POSTED_SOCIAL_FILE = path.join(PROJECT, 'social-posted-content.json');
 const WEBSITE_BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.natureswaysoil.com';
+const ALL_PLATFORMS = ['instagram', 'twitter', 'youtube', 'facebook', 'pinterest'];
+
+function requestedPlatforms(env = process.env) {
+  return String(env.ENABLE_PLATFORMS || '')
+    .split(',')
+    .map((platform) => platform.trim().toLowerCase())
+    .filter((platform) => ALL_PLATFORMS.includes(platform));
+}
+
+function configuredPlatforms(env = process.env) {
+  const configured = [];
+  if (env.INSTAGRAM_ACCESS_TOKEN && env.INSTAGRAM_IG_ID) configured.push('instagram');
+  if (
+    env.TWITTER_API_KEY &&
+    env.TWITTER_API_SECRET &&
+    env.TWITTER_ACCESS_TOKEN &&
+    (env.TWITTER_ACCESS_TOKEN_SECRET || env.TWITTER_ACCESS_SECRET)
+  ) configured.push('twitter');
+  if (env.YT_CLIENT_ID && env.YT_CLIENT_SECRET && env.YT_REFRESH_TOKEN) configured.push('youtube');
+  if (env.FACEBOOK_PAGE_ID && (env.FACEBOOK_PAGE_ACCESS_TOKEN || env.FACEBOOK_ACCESS_TOKEN)) configured.push('facebook');
+  if (env.PINTEREST_ACCESS_TOKEN && env.PINTEREST_BOARD_ID) configured.push('pinterest');
+
+  const requested = requestedPlatforms(env);
+
+  return requested.length
+    ? configured.filter((platform) => requested.includes(platform))
+    : configured;
+}
 
 class SocialMediaAutoPoster {
   constructor() {
@@ -89,13 +117,7 @@ class SocialMediaAutoPoster {
   }
 
   getActivePlatforms() {
-    const active = [];
-    if (INSTAGRAM_ACCESS_TOKEN && INSTAGRAM_IG_ID) active.push('instagram');
-    if (process.env.TWITTER_API_KEY && process.env.TWITTER_ACCESS_TOKEN) active.push('twitter');
-    if (process.env.YT_CLIENT_ID && process.env.YT_CLIENT_SECRET && process.env.YT_REFRESH_TOKEN) active.push('youtube');
-    if (FACEBOOK_PAGE_ID && (FACEBOOK_PAGE_ACCESS_TOKEN || FACEBOOK_ACCESS_TOKEN)) active.push('facebook');
-    if (PINTEREST_ACCESS_TOKEN && PINTEREST_BOARD_ID) active.push('pinterest');
-    return active;
+    return configuredPlatforms(process.env);
   }
 
   log(message) {
@@ -1040,6 +1062,14 @@ class SocialMediaAutoPoster {
 
       const activePlatforms = this.getActivePlatforms();
       this.log(`Active platforms this run: ${activePlatforms.join(', ') || 'none configured'}`);
+      const requested = requestedPlatforms(process.env);
+      const missing = requested.filter((platform) => !activePlatforms.includes(platform));
+      if (missing.length) {
+        throw new Error(`Enabled platform credentials are incomplete: ${missing.join(', ')}`);
+      }
+      if (!activePlatforms.length) {
+        throw new Error('No social platforms are configured. Bind credentials to the job or set valid ENABLE_PLATFORMS values.');
+      }
 
       this.log(`Found ${products.length} products to process`);
 
@@ -1071,7 +1101,7 @@ class SocialMediaAutoPoster {
 
       try {
 
-          // Instagram posting
+        if (activePlatforms.includes('instagram')) {
           try {
             const igResult = await this.postToInstagram(product);
             if (igResult.postId && !igResult.postId.includes('placeholder')) {
@@ -1082,8 +1112,9 @@ class SocialMediaAutoPoster {
           } catch (error) {
             results.errors.instagram.push({ productId: product.id, error: error.message });
           }
+        }
 
-          // Twitter posting
+        if (activePlatforms.includes('twitter')) {
           try {
             const twitterResult = await this.postToTwitter(product);
             if (twitterResult.tweetId) {
@@ -1094,8 +1125,9 @@ class SocialMediaAutoPoster {
           } catch (error) {
             results.errors.twitter.push({ productId: product.id, error: error.message });
           }
+        }
 
-          // YouTube upload preparation
+        if (activePlatforms.includes('youtube')) {
           try {
             const ytResult = await this.uploadToYouTube(product);
             if (ytResult.videoId) {
@@ -1106,8 +1138,9 @@ class SocialMediaAutoPoster {
           } catch (error) {
             results.errors.youtube.push({ productId: product.id, error: error.message });
           }
+        }
 
-          // Facebook posting
+        if (activePlatforms.includes('facebook')) {
           try {
             const fbResult = await this.postToFacebook(product);
             if (fbResult.postId) {
@@ -1118,8 +1151,9 @@ class SocialMediaAutoPoster {
           } catch (error) {
             results.errors.facebook.push({ productId: product.id, error: error.message });
           }
+        }
 
-          // Pinterest posting
+        if (activePlatforms.includes('pinterest')) {
           try {
             const pinResult = await this.postToPinterest(product);
             if (pinResult.pinId) {
@@ -1130,6 +1164,7 @@ class SocialMediaAutoPoster {
           } catch (error) {
             results.errors.pinterest.push({ productId: product.id, error: error.message });
           }
+        }
 
       } catch (error) {
         this.log(`Error processing ${product.id}: ${error.message}`);
@@ -1184,6 +1219,20 @@ class SocialMediaAutoPoster {
         }
       });
 
+      const successCount = activePlatforms.reduce(
+        (total, platform) => total + results.success[platform].length,
+        0
+      );
+      const errorCount = activePlatforms.reduce(
+        (total, platform) => total + results.errors[platform].length,
+        0
+      );
+      if (successCount === 0 || errorCount > 0) {
+        throw new Error(
+          `Social posting incomplete: ${successCount} successful post(s), ${errorCount} error(s) across ${activePlatforms.join(', ')}`
+        );
+      }
+
       return results;
 
     } catch (error) {
@@ -1211,7 +1260,7 @@ async function main() {
 }
 
 // Export for use in other modules
-export { SocialMediaAutoPoster };
+export { ALL_PLATFORMS, SocialMediaAutoPoster, configuredPlatforms, requestedPlatforms };
 
 // Run if called directly
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/tests/social-platform-selection.test.mjs
+++ b/scripts/tests/social-platform-selection.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { configuredPlatforms } from '../social-media-auto-post.mjs';
+
+test('returns no platforms when credentials are absent', () => {
+  assert.deepEqual(configuredPlatforms({}), []);
+});
+
+test('returns only fully configured platforms', () => {
+  assert.deepEqual(configuredPlatforms({
+    TWITTER_API_KEY: 'key',
+    TWITTER_API_SECRET: 'secret',
+    TWITTER_ACCESS_TOKEN: 'token',
+    TWITTER_ACCESS_SECRET: 'access-secret',
+    INSTAGRAM_ACCESS_TOKEN: 'partial'
+  }), ['twitter']);
+});
+
+test('ENABLE_PLATFORMS restricts configured platforms', () => {
+  assert.deepEqual(configuredPlatforms({
+    ENABLE_PLATFORMS: 'youtube,twitter',
+    TWITTER_API_KEY: 'key',
+    TWITTER_API_SECRET: 'secret',
+    TWITTER_ACCESS_TOKEN: 'token',
+    TWITTER_ACCESS_TOKEN_SECRET: 'access-secret',
+    YT_CLIENT_ID: 'id',
+    YT_CLIENT_SECRET: 'secret',
+    YT_REFRESH_TOKEN: 'refresh',
+    PINTEREST_ACCESS_TOKEN: 'pin',
+    PINTEREST_BOARD_ID: 'board'
+  }), ['twitter', 'youtube']);
+});


### PR DESCRIPTION
## What changed

- load Google Secret Manager values through the Cloud Run metadata identity, with a local `gcloud` fallback
- support a separate `SECRET_PROJECT_ID` for cross-project video credentials
- attempt only enabled platforms with complete credentials
- fail the job when enabled credentials are incomplete or no social post succeeds
- add focused platform-selection tests

## Root cause

The `nws-video-generator` job runs in `amazon-ppc-bid-optimizer`, while its social credentials live in `natureswaysoil-video`. The legacy loader silently returned no values, and the poster attempted every platform even though it reported `active_platforms=none`. All failures were summarized but the process still exited successfully.

## Validation

- `node --check scripts/run-seed-rotation.mjs`
- `node --check scripts/social-media-auto-post.mjs`
- `node --test scripts/tests/social-platform-selection.test.mjs`
- `npm run build`
