### PR TITLE
Scope scheduled seed video generation

### DIFF
--- a/scripts/cloud-video-social-job.mjs
+++ b/scripts/cloud-video-social-job.mjs
@@ -21,7 +21,12 @@ const __dirname = path.dirname(__filename);
 const PROJECT = path.resolve(__dirname, '..');
 const VIDEOS_DIR = path.join(PROJECT, 'public', 'videos');
 const PLANS_DIR = path.join(PROJECT, 'content', 'generated-videos');
-const SECRET_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || process.env.PROJECT_ID;
+const SECRET_PROJECT_ID =
+  process.env.SECRET_PROJECT_ID ||
+  process.env.GOOGLE_CLOUD_PROJECT ||
+  process.env.GCLOUD_PROJECT ||
+  process.env.GCP_PROJECT ||
+  process.env.PROJECT_ID;
 const DEFAULT_SITE_URL = 'https://www.natureswaysoil.com';
 const SECRET_NAMES = [
   'PEXELS_API_KEY',
@@ -148,7 +153,7 @@ function main() {
   console.log('[Cloud Video Job] Starting Nature\'s Way Soil video + social pipeline.');
   hydrateSecrets();
   setWebsiteVideoEnvironment();
-  console.log('[Cloud Video Job] Generating five video rotations for each top-five product...');
+  console.log('[Cloud Video Job] Generating configured product video rotation(s)...');
   run('node', ['scripts/create-five-product-video-rotation.mjs']);
   uploadOutputsToCloudStorage();
   runSocialPoster();

--- a/scripts/create-five-product-video-rotation.mjs
+++ b/scripts/create-five-product-video-rotation.mjs
@@ -23,6 +23,7 @@ const PROJECT = path.resolve(__dirname, '..');
 const TOP_PRODUCTS_FILE = path.join(PROJECT, 'config', 'top-products.json');
 const VIDEOS_DIR = path.join(PROJECT, 'public', 'videos');
 const VARIATIONS_PER_PRODUCT = Number(process.env.VIDEO_VARIATIONS_PER_PRODUCT || 5);
+const PRODUCT_LIMIT = Math.max(1, Number(process.env.SEED_PRODUCT_LIMIT || 5));
 
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -46,10 +47,16 @@ function copyIfExists(from, to) {
 
 function products() {
   const topProducts = readJson(TOP_PRODUCTS_FILE).topProducts || [];
-  return topProducts
+  const requestedProductId = process.env.PRODUCT_ID || process.env.VIDEO_PRODUCT_ID;
+  const ordered = topProducts
     .slice()
-    .sort((a, b) => (a.priority || 999) - (b.priority || 999))
-    .slice(0, 5);
+    .sort((a, b) => (a.priority || 999) - (b.priority || 999));
+
+  if (requestedProductId) {
+    return ordered.filter((product) => product.id === requestedProductId);
+  }
+
+  return ordered.slice(0, PRODUCT_LIMIT);
 }
 
 function cleanOldRotationFiles(productId) {
@@ -64,7 +71,9 @@ function cleanOldRotationFiles(productId) {
 async function main() {
   fs.mkdirSync(VIDEOS_DIR, { recursive: true });
   const selected = products();
-  if (selected.length !== 5) throw new Error(`Expected 5 top products, found ${selected.length}`);
+  if (!selected.length) {
+    throw new Error(`No matching top product found for ${process.env.PRODUCT_ID || process.env.VIDEO_PRODUCT_ID || 'configured selection'}`);
+  }
 
   console.log(`[Video Rotation] Building ${VARIATIONS_PER_PRODUCT} video file(s) for each of ${selected.length} products.`);
 


### PR DESCRIPTION
## What changed

- honor `PRODUCT_ID` / `VIDEO_PRODUCT_ID` when selecting products to render
- honor `SEED_PRODUCT_LIMIT` when no explicit product is selected
- allow a scheduled run to generate one variation instead of requiring five products
- use `SECRET_PROJECT_ID` inside the child video pipeline

## Root cause

The scheduled `NWS_014` run ignored its product selection and rendered five variations for each of five products. High-quality vertical renders take about 12 minutes each, so the Cloud Run task timed out during the third variation of the first product.

## Validation

- `node --check scripts/create-five-product-video-rotation.mjs`
- `node --check scripts/cloud-video-social-job.mjs`
- `git diff --check`
