### PR TITLE
Fix top product social posting

### DIFF
--- a/.github/workflows/manual-social-post.yml
+++ b/.github/workflows/manual-social-post.yml
@@ -62,10 +62,27 @@ jobs:
       - name: Load social secrets
         run: |
           set -euo pipefail
+          SECRET_PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-natureswaysoil-video}"
+          ACTIVE_ACCOUNT="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' | head -n 1)"
+          echo "Loading social credentials as ${ACTIVE_ACCOUNT} from project ${SECRET_PROJECT_ID}"
+
           load_secret () {
-            if gcloud secrets describe "$1" >/dev/null 2>&1; then
-              echo "$2=$(gcloud secrets versions access latest --secret=$1)" >> "$GITHUB_ENV"
+            local value
+            if ! value="$(gcloud secrets versions access latest --secret="$1" --project="$SECRET_PROJECT_ID" 2>/tmp/social-secret-error)"; then
+              echo "::warning::Could not load $1: $(tr '\n' ' ' </tmp/social-secret-error)"
+              return 0
             fi
+            if [ -z "$value" ]; then
+              echo "::warning::Secret $1 is empty"
+              return 0
+            fi
+            echo "::add-mask::$value"
+            {
+              echo "$2<<SOCIAL_SECRET_EOF"
+              echo "$value"
+              echo "SOCIAL_SECRET_EOF"
+            } >> "$GITHUB_ENV"
+            echo "Loaded $2"
           }
           load_secret INSTAGRAM_ACCESS_TOKEN INSTAGRAM_ACCESS_TOKEN
           load_secret INSTAGRAM_IG_ID INSTAGRAM_IG_ID
@@ -73,12 +90,28 @@ jobs:
           load_secret FACEBOOK_ACCESS_TOKEN FACEBOOK_ACCESS_TOKEN
           load_secret FACEBOOK_PAGE_ACCESS_TOKEN FACEBOOK_PAGE_ACCESS_TOKEN
           load_secret TWITTER_API_KEY TWITTER_API_KEY
+          load_secret TWITTER_API_SECRET TWITTER_API_SECRET
           load_secret TWITTER_ACCESS_TOKEN TWITTER_ACCESS_TOKEN
+          load_secret TWITTER_ACCESS_SECRET TWITTER_ACCESS_SECRET
+          load_secret TWITTER_CLIENT_ID TWITTER_CLIENT_ID
+          load_secret TWITTER_CLIENT_SECRET TWITTER_CLIENT_SECRET
+          load_secret TWITTER_REFRESH_TOKEN TWITTER_REFRESH_TOKEN
           load_secret YT_CLIENT_ID YT_CLIENT_ID
           load_secret YT_CLIENT_SECRET YT_CLIENT_SECRET
           load_secret YT_REFRESH_TOKEN YT_REFRESH_TOKEN
           load_secret PINTEREST_ACCESS_TOKEN PINTEREST_ACCESS_TOKEN
           load_secret PINTEREST_BOARD_ID PINTEREST_BOARD_ID
+
+      - name: Validate social platform configuration
+        run: |
+          node --input-type=module <<'NODE'
+          import { configuredPlatforms } from './scripts/social-media-auto-post.mjs';
+          const platforms = configuredPlatforms(process.env);
+          if (!platforms.length) {
+            throw new Error('No complete social credential set was loaded from Secret Manager.');
+          }
+          console.log(`Configured social platforms: ${platforms.join(', ')}`);
+          NODE
 
       - name: Generate preview
         env:
@@ -97,5 +130,6 @@ jobs:
           PRODUCT_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.product_id || '' }}
           POST_MODE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.post_mode || 'auto' }}
           SOCIAL_FORCE_IMAGE_ONLY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_image_only || '0' }}
+          ENABLE_PLATFORMS: 'instagram,twitter,youtube,facebook,pinterest'
           NEXT_PUBLIC_SITE_URL: 'https://www.natureswaysoil.com'
         run: node scripts/social-media-top5-post.mjs

--- a/scripts/social-media-auto-post.mjs
+++ b/scripts/social-media-auto-post.mjs
@@ -146,6 +146,21 @@ class SocialMediaAutoPoster {
 
   loadProducts() {
     try {
+      const lockedProductId = process.env.PRODUCT_ID;
+      const suppliedProductJson = process.env.SOCIAL_PRODUCT_JSON;
+      if (suppliedProductJson) {
+        const suppliedProduct = JSON.parse(suppliedProductJson);
+        if (
+          suppliedProduct?.id &&
+          suppliedProduct?.name &&
+          (!lockedProductId || suppliedProduct.id === lockedProductId)
+        ) {
+          this.log(`Using controller-supplied product: ${suppliedProduct.id}`);
+          return [suppliedProduct];
+        }
+        throw new Error('SOCIAL_PRODUCT_JSON does not match the requested PRODUCT_ID');
+      }
+
       // Prefer Google Sheets cache when available so product selection follows sheet data.
       if (fs.existsSync(SHEET_PRODUCTS_FILE)) {
         const sheetData = JSON.parse(fs.readFileSync(SHEET_PRODUCTS_FILE, 'utf8'));
@@ -199,8 +214,6 @@ class SocialMediaAutoPoster {
       }
 
       const filteredProducts = products.filter(p => /^NWS_\d{3}$/.test(p.id));
-      const lockedProductId = process.env.PRODUCT_ID;
-
       if (lockedProductId) {
         const lockedProducts = filteredProducts.filter((p) => p.id === lockedProductId);
         if (lockedProducts.length > 0) {
@@ -208,6 +221,9 @@ class SocialMediaAutoPoster {
           return lockedProducts;
         }
         this.log(`PRODUCT_ID lock requested but not found: ${lockedProductId}`);
+        if (process.env.SOCIAL_TOP5_LOCK === '1') {
+          throw new Error(`Locked product ${lockedProductId} is not available in the posting catalog`);
+        }
       }
 
       return filteredProducts;

--- a/scripts/social-media-top5-post.mjs
+++ b/scripts/social-media-top5-post.mjs
@@ -38,7 +38,27 @@ function writeJson(file, data) {
 
 function loadTopProducts() {
   const config = readJson(CONFIG_FILE, { topProducts: [] });
-  return [...config.topProducts].sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999));
+  const products = [...config.topProducts]
+    .map((product) => ({
+      ...product,
+      funnelUrl: product.funnelUrl || product.websiteUrl || `/product/${product.id}`,
+      checkoutUrl: product.checkoutUrl || product.amazonUrl || `/checkout?productId=${product.id}`,
+    }))
+    .sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999));
+
+  const eligible = products.filter((product) =>
+    fs.existsSync(path.join(PROJECT, 'public', 'videos', `${product.id}.mp4`))
+  );
+  const skipped = products.filter((product) => !eligible.includes(product));
+  if (skipped.length) {
+    console.warn(
+      `Skipping products without canonical videos: ${skipped.map((product) => product.id).join(', ')}`
+    );
+  }
+  if (!eligible.length) {
+    throw new Error('No top products have a canonical public/videos/{PRODUCT_ID}.mp4 asset.');
+  }
+  return eligible;
 }
 
 function loadVariations() {
@@ -106,6 +126,7 @@ function postProduct(product, state, variationsConfig) {
     env: {
       ...process.env,
       PRODUCT_ID: product.id,
+      SOCIAL_PRODUCT_JSON: JSON.stringify(product),
       PRODUCT_FUNNEL_URL: product.funnelUrl,
       PRODUCT_CHECKOUT_URL: product.checkoutUrl,
       SOCIAL_TOP5_LOCK: '1',


### PR DESCRIPTION
## Fixes
- exclude top-five products that do not have a canonical published video
- pass the selected product record into the posting engine instead of requiring a duplicate catalog entry
- supply funnel and checkout URL defaults
- load all required platform credentials from the explicit GCP project
- surface the active service account and individual Secret Manager failures
- validate that at least one complete platform credential set was loaded before posting

## Validation
- Node syntax checks
- social platform selection tests (3 passed)
- production Next.js build
- workflow YAML parse