### PR TITLE
Block broken videos from social publishing

### DIFF
--- a/scripts/cloud-video-social-job.mjs
+++ b/scripts/cloud-video-social-job.mjs
@@ -31,6 +31,7 @@ const DEFAULT_SITE_URL = 'https://www.natureswaysoil.com';
 const SECRET_NAMES = [
   'PEXELS_API_KEY',
   'OPENAI_API_KEY',
+  'OPENAI_API_KEY',
   'NEXT_PUBLIC_SITE_URL',
   'VIDEO_OUTPUT_BUCKET',
   'VIDEO_OUTPUT_PREFIX',
@@ -159,6 +160,18 @@ function main() {
   setWebsiteVideoEnvironment();
   console.log('[Cloud Video Job] Generating configured product video rotation(s)...');
   run('node', ['scripts/create-five-product-video-rotation.mjs']);
+  const topProducts = JSON.parse(
+    fs.readFileSync(path.join(PROJECT, 'config', 'top-products.json'), 'utf8')
+  ).topProducts || [];
+  const productIds = topProducts.slice(0, 5).map((product) => product.id).filter(Boolean);
+  console.log('[Cloud Video Job] Adding narration/audio before publishing...');
+  run('node', ['scripts/add-audio-to-seed-videos.mjs'], {
+    env: {
+      ...process.env,
+      PRODUCT_IDS: productIds.join(','),
+      REPLACE_ORIGINAL_AUDIO: '1'
+    }
+  });
   uploadOutputsToCloudStorage();
   runSocialPoster();
   console.log('[Cloud Video Job] Done.');

--- a/scripts/create-quality-seed-videos.mjs
+++ b/scripts/create-quality-seed-videos.mjs
@@ -359,7 +359,11 @@ function brollScene(input, text, out, seconds) {
 async function build(product) {
   validateSeed(product);
   const images = productImages(product);
-  if (!images.length) console.log(`No usable product images found for ${product.id}; using branded motion fallback for product cards.`);
+  if (!images.length) {
+    throw new Error(
+      `${product.id} has no usable product image. Refusing to generate a product video without showing the product.`
+    );
+  }
   const work = fs.mkdtempSync(path.join(os.tmpdir(), `nws_quality_${product.id}_`));
   const scenes = [];
   const audit = [];
@@ -397,6 +401,17 @@ async function build(product) {
     scenes.push(out);
   }
 
+  const realBrollCount = audit.filter((scene) =>
+    ['pexels-broll', 'local-broll', 'product-image-motion'].includes(scene.type)
+  ).length;
+  const fallbackCount = audit.filter((scene) => scene.type === 'branded-motion-fallback').length;
+  if (fallbackCount > 0 || realBrollCount < 4) {
+    throw new Error(
+      `${product.id} failed visual QA: ${realBrollCount} real b-roll scenes, ` +
+      `${fallbackCount} branded fallback scenes. Require at least 4 real scenes and zero fallbacks.`
+    );
+  }
+
   const concat = path.join(work, 'concat.txt');
   fs.writeFileSync(concat, scenes.map((file) => `file '${file.replace(/'/g, "'\\''")}'`).join('\n'));
   const mp4 = path.join(OUT_DIR, `${product.id}.mp4`);
@@ -405,6 +420,18 @@ async function build(product) {
   run('ffmpeg', ['-y', '-hide_banner', '-loglevel', 'error', '-ss', '00:00:01', '-i', mp4, '-frames:v', '1', '-q:v', '2', jpg]);
   const probe = capture('ffprobe', ['-v', 'error', '-show_entries', 'stream=width,height,duration', '-of', 'json', mp4]);
   const metadata = probe ? JSON.parse(probe).streams?.[0] || {} : {};
+  const outputBytes = fs.statSync(mp4).size;
+  if (
+    Number(metadata.width) !== W ||
+    Number(metadata.height) !== H ||
+    Number(metadata.duration || 0) < 20 ||
+    outputBytes < 750_000
+  ) {
+    throw new Error(
+      `${product.id} failed output QA: ${metadata.width || 0}x${metadata.height || 0}, ` +
+      `${Number(metadata.duration || 0).toFixed(1)}s, ${outputBytes} bytes.`
+    );
+  }
   const actualDuration = Number(metadata.duration || 0);
   if (actualDuration < MIN_VIDEO_SECONDS || actualDuration > MAX_VIDEO_SECONDS) {
     throw new Error(`${product.id} failed duration QA: ${actualDuration.toFixed(2)}s (required ${MIN_VIDEO_SECONDS}-${MAX_VIDEO_SECONDS}s).`);

--- a/scripts/lib/video-publish-qa.mjs
+++ b/scripts/lib/video-publish-qa.mjs
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import { spawnSync } from 'child_process';
+
+export function assessVideoProbe({ fileSize = 0, format = {}, streams = [] } = {}) {
+  const video = streams.find((stream) => stream.codec_type === 'video') || {};
+  const audio = streams.find((stream) => stream.codec_type === 'audio') || {};
+  const duration = Number(format.duration || video.duration || 0);
+  const width = Number(video.width || 0);
+  const height = Number(video.height || 0);
+  const failures = [];
+
+  if (width < 720 || height < 720) failures.push(`resolution ${width}x${height} is below 720px`);
+  if (duration < 20 || duration > 45) failures.push(`duration ${duration.toFixed(1)}s is outside 20-45s`);
+  if (!audio.codec_name) failures.push('audio stream is missing');
+  if (fileSize < 750_000) failures.push(`file is only ${fileSize} bytes`);
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    width,
+    height,
+    duration,
+    hasAudio: Boolean(audio.codec_name),
+    fileSize
+  };
+}
+
+export function validateVideoForPublishing(videoPath, { ffprobe = 'ffprobe' } = {}) {
+  if (!fs.existsSync(videoPath)) throw new Error(`Video file is missing: ${videoPath}`);
+  const result = spawnSync(ffprobe, [
+    '-v', 'error',
+    '-show_entries', 'format=duration:stream=codec_name,codec_type,width,height,duration',
+    '-of', 'json',
+    videoPath
+  ], { encoding: 'utf8', timeout: 30_000 });
+  if (result.status !== 0) {
+    throw new Error(`Video QA could not inspect ${videoPath}: ${String(result.stderr || '').trim()}`);
+  }
+  const probe = JSON.parse(result.stdout || '{}');
+  const assessment = assessVideoProbe({
+    ...probe,
+    fileSize: fs.statSync(videoPath).size
+  });
+  if (!assessment.ok) {
+    throw new Error(`Video failed publish QA: ${assessment.failures.join('; ')}`);
+  }
+  return assessment;
+}

--- a/scripts/social-caption-overrides.mjs
+++ b/scripts/social-caption-overrides.mjs
@@ -4,8 +4,13 @@ export function buildForcedSocialContent({ product, platform, baseUrl }) {
   const angle = process.env.SOCIAL_VARIATION_ANGLE || '';
   const funnelUrl = process.env.PRODUCT_FUNNEL_URL || `/product/${product.id}`;
   const checkoutUrl = process.env.PRODUCT_CHECKOUT_URL || `/checkout?productId=${product.id}&coupon=SAVE15`;
-  const fullFunnelUrl = `${baseUrl}${funnelUrl}`;
-  const fullCheckoutUrl = `${baseUrl}${checkoutUrl}`;
+  const absoluteUrl = (value) => {
+    const candidate = String(value || '').trim();
+    if (/^https?:\/\//i.test(candidate)) return candidate;
+    return new URL(candidate || '/', `${String(baseUrl).replace(/\/+$/, '')}/`).toString();
+  };
+  const fullFunnelUrl = absoluteUrl(funnelUrl);
+  const fullCheckoutUrl = absoluteUrl(checkoutUrl);
 
   if (!hook && !caption) return null;
 

--- a/scripts/social-media-auto-post.mjs
+++ b/scripts/social-media-auto-post.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'url';
 import { createHmac } from 'crypto';
 import { buildForcedSocialContent } from './social-caption-overrides.mjs';
 import { createTwitterOAuth2UserClient, hasTwitterOAuth2User } from './twitter-oauth2.mjs';
+import { validateVideoForPublishing } from './lib/video-publish-qa.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PROJECT = path.resolve(__dirname, '..');
@@ -95,6 +96,16 @@ class SocialMediaAutoPoster {
     }
 
     return true;
+  }
+
+  assertPublishableVideo(product) {
+    const assessment = validateVideoForPublishing(this.getVideoPath(product));
+    this.log(
+      `Video QA passed for ${product.id}: ${assessment.width}x${assessment.height}, ` +
+      `${assessment.duration.toFixed(1)}s, audio=${assessment.hasAudio}, ` +
+      `${(assessment.fileSize / 1024 / 1024).toFixed(1)}MB`
+    );
+    return assessment;
   }
 
   warnRootLevelMp4Ignored() {
@@ -740,6 +751,7 @@ class SocialMediaAutoPoster {
         throw new Error(`No video file found at ${videoPath} — run HeyGen generation first`);
       }
 
+      this.assertPublishableVideo(product);
       this.log(`Uploading ${product.id} to YouTube...`);
 
       // Step 1: Get fresh access token
@@ -1128,6 +1140,7 @@ class SocialMediaAutoPoster {
       const product = unposted[0];
       this.log(`Selected product for this run: ${product.name} (${product.id})`);
       this.log(`SCHEDULE_TICK product_id=${product.id} run_at=${new Date().toISOString()} active_platforms=${activePlatforms.join(',') || 'none'}`);
+      this.assertPublishableVideo(product);
 
       const results = {
         success: { instagram: [], twitter: [], youtube: [], facebook: [], pinterest: [] },

--- a/scripts/tests/video-publish-qa.test.mjs
+++ b/scripts/tests/video-publish-qa.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { assessVideoProbe } from '../lib/video-publish-qa.mjs';
+import { buildForcedSocialContent } from '../social-caption-overrides.mjs';
+
+test('rejects the low-resolution fallback video that reached YouTube', () => {
+  const result = assessVideoProbe({
+    fileSize: 280_000,
+    format: { duration: '30.14' },
+    streams: [
+      { codec_type: 'video', codec_name: 'h264', width: 640, height: 360 },
+      { codec_type: 'audio', codec_name: 'aac' }
+    ]
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.failures.join(' '), /resolution/);
+  assert.match(result.failures.join(' '), /file is only/);
+});
+
+test('accepts a production vertical video with audio', () => {
+  const result = assessVideoProbe({
+    fileSize: 4_000_000,
+    format: { duration: '29.8' },
+    streams: [
+      { codec_type: 'video', codec_name: 'h264', width: 1080, height: 1920 },
+      { codec_type: 'audio', codec_name: 'aac' }
+    ]
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('does not prefix the website onto an absolute checkout URL', () => {
+  const previous = {
+    hook: process.env.SOCIAL_VARIATION_HOOK,
+    caption: process.env.SOCIAL_VARIATION_CAPTION,
+    checkout: process.env.PRODUCT_CHECKOUT_URL
+  };
+  process.env.SOCIAL_VARIATION_HOOK = 'Dog spots got you down?';
+  process.env.SOCIAL_VARIATION_CAPTION = 'Repair yellow spots at the soil level.';
+  process.env.PRODUCT_CHECKOUT_URL = 'https://www.amazon.com/dp/B0FG38YYJ5';
+  try {
+    const content = buildForcedSocialContent({
+      product: { id: 'NWS_014', name: 'Dog Urine Neutralizer' },
+      platform: 'youtube',
+      baseUrl: 'https://www.natureswaysoil.com'
+    });
+    assert.match(content.description, /Quick checkout:\nhttps:\/\/www\.amazon\.com\/dp\/B0FG38YYJ5/);
+    assert.doesNotMatch(content.description, /natureswaysoil\.comhttps/);
+  } finally {
+    if (previous.hook === undefined) delete process.env.SOCIAL_VARIATION_HOOK;
+    else process.env.SOCIAL_VARIATION_HOOK = previous.hook;
+    if (previous.caption === undefined) delete process.env.SOCIAL_VARIATION_CAPTION;
+    else process.env.SOCIAL_VARIATION_CAPTION = previous.caption;
+    if (previous.checkout === undefined) delete process.env.PRODUCT_CHECKOUT_URL;
+    else process.env.PRODUCT_CHECKOUT_URL = previous.checkout;
+  }
+});


### PR DESCRIPTION
Prevents blank/low-quality fallback videos from reaching YouTube and other social platforms.

Root cause confirmed from https://www.youtube.com/watch?v=pnb6xOrzjb4:
- 640x360, ~280 KB
- dark branded fallback background instead of product/b-roll
- overflowing text
- no YouTube captions
- malformed `natureswaysoil.comhttps://amazon.com/...` checkout URL

Fixes:
- require a usable product image
- require at least four real visual scenes and zero branded fallbacks
- require 20-45 seconds, expected render dimensions, and minimum output size
- add narration/audio before upload
- run fail-closed ffprobe QA before any social publishing
- correctly preserve absolute checkout/funnel URLs

Validation: syntax checks pass; `node --test scripts/tests/video-publish-qa.test.mjs` passes 3/3.