### PR TITLE
Enforce production video generation quality

### DIFF
--- a/.github/workflows/generate-one-video.yml
+++ b/.github/workflows/generate-one-video.yml
@@ -10,16 +10,19 @@ on:
   push:
     paths:
       - .github/workflows/generate-one-video.yml
-      - scripts/create-one-test-video.mjs
       - scripts/create-quality-seed-videos.mjs
+      - scripts/add-audio-to-seed-videos.mjs
+      - scripts/lib/video-publish-qa.mjs
       - config/top-products.json
 
 jobs:
   generate-one-video:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       PRODUCT_ID: ${{ github.event.inputs.product_id || 'NWS_014' }}
-      PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -38,13 +41,73 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate one video
-        run: node scripts/create-one-test-video.mjs
+      - name: Check Google Cloud credentials
+        env:
+          GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$GCP_SERVICE_ACCOUNT_JSON" ]; then
+            echo "Missing GitHub secret: GCP_SERVICE_ACCOUNT_JSON"
+            exit 1
+          fi
 
-      - name: Verify generated video
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Load required video-generation secrets
+        env:
+          REPOSITORY_PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
+          REPOSITORY_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          SECRET_PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-natureswaysoil-video}"
+
+          load_required_secret () {
+            local secret_name="$1"
+            local env_name="$2"
+            local repository_value="$3"
+            local value="$repository_value"
+
+            if [ -z "$value" ]; then
+              value="$(gcloud secrets versions access latest --secret="$secret_name" --project="$SECRET_PROJECT_ID")"
+            fi
+            if [ -z "$value" ]; then
+              echo "Required secret $secret_name is empty"
+              exit 1
+            fi
+
+            echo "::add-mask::$value"
+            {
+              echo "$env_name<<VIDEO_SECRET_EOF"
+              echo "$value"
+              echo "VIDEO_SECRET_EOF"
+            } >> "$GITHUB_ENV"
+          }
+
+          load_required_secret PEXELS_API_KEY PEXELS_API_KEY "$REPOSITORY_PEXELS_API_KEY"
+          load_required_secret OPENAI_API_KEY OPENAI_API_KEY "$REPOSITORY_OPENAI_API_KEY"
+
+      - name: Generate production-quality video
+        run: node scripts/create-quality-seed-videos.mjs
+
+      - name: Add narration and audio
+        env:
+          PRODUCT_IDS: ${{ env.PRODUCT_ID }}
+          REPLACE_ORIGINAL_AUDIO: '1'
+        run: node scripts/add-audio-to-seed-videos.mjs
+
+      - name: Enforce publishing quality
         run: |
           test -f public/videos/${PRODUCT_ID}.mp4
-          ffprobe -v error -show_entries stream=width,height,duration -of json public/videos/${PRODUCT_ID}.mp4
+          VIDEO_PATH="public/videos/${PRODUCT_ID}.mp4" node --input-type=module -e "
+            import { validateVideoForPublishing } from './scripts/lib/video-publish-qa.mjs';
+            const result = validateVideoForPublishing(process.env.VIDEO_PATH);
+            console.log(JSON.stringify(result, null, 2));
+          "
 
       - name: Upload generated video artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/generate-one-video.yml
+++ b/.github/workflows/generate-one-video.yml
@@ -13,6 +13,7 @@ on:
       - scripts/create-quality-seed-videos.mjs
       - scripts/add-audio-to-seed-videos.mjs
       - scripts/lib/video-publish-qa.mjs
+      - scripts/lib/video-text.mjs
       - config/top-products.json
 
 jobs:

--- a/scripts/create-quality-seed-videos.mjs
+++ b/scripts/create-quality-seed-videos.mjs
@@ -25,6 +25,7 @@ import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
+import { wrapVideoText } from './lib/video-text.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -102,18 +103,7 @@ function clean(text) {
     .trim();
 }
 function wrap(text, max = 26) {
-  return clean(text).split('\n').map((line) => {
-    const words = line.split(' ');
-    const lines = [];
-    let current = '';
-    for (const word of words) {
-      const next = current ? `${current} ${word}` : word;
-      if (next.length > max && current) { lines.push(current); current = word; }
-      else current = next;
-    }
-    if (current) lines.push(current);
-    return lines.slice(0, 4).join('\n');
-  }).join('\n');
+  return wrapVideoText(clean(text), max, 4);
 }
 function textFile(text, max = 26) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nws_video_text_'));

--- a/scripts/lib/video-text.mjs
+++ b/scripts/lib/video-text.mjs
@@ -1,0 +1,48 @@
+export function wrapVideoText(text, max = 26, maxLines = 4) {
+  const normalized = String(text || '')
+    .replace(/%/g, ' percent')
+    .replace(/[“”]/g, '"')
+    .replace(/[’]/g, "'")
+    .replace(/[—–]/g, '-')
+    .replace(/[\r\t]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const words = normalized.split(' ').filter(Boolean);
+  const lines = [];
+  let current = '';
+
+  const push = (line) => {
+    if (line && lines.length < maxLines) lines.push(line);
+  };
+  const splitLongWord = (word) => {
+    const chunks = [];
+    let remaining = word;
+    while (remaining.length > max) {
+      const window = remaining.slice(0, max);
+      const slash = window.lastIndexOf('/');
+      const hyphen = window.lastIndexOf('-');
+      const delimiter = Math.max(slash, hyphen);
+      const cut = delimiter >= Math.ceil(max * 0.55) ? delimiter + 1 : max;
+      chunks.push(remaining.slice(0, cut));
+      remaining = remaining.slice(cut);
+    }
+    if (remaining) chunks.push(remaining);
+    return chunks;
+  };
+
+  for (const word of words) {
+    for (const chunk of splitLongWord(word)) {
+      const next = current ? `${current} ${chunk}` : chunk;
+      if (next.length > max && current) {
+        push(current);
+        current = chunk;
+      } else {
+        current = next;
+      }
+      if (lines.length >= maxLines) break;
+    }
+    if (lines.length >= maxLines) break;
+  }
+  if (lines.length < maxLines) push(current);
+  return lines.join('\n');
+}

--- a/scripts/tests/video-text.test.mjs
+++ b/scripts/tests/video-text.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { wrapVideoText } from '../lib/video-text.mjs';
+
+test('wraps long landing-page URLs without overflowing the end card', () => {
+  const wrapped = wrapVideoText(
+    'Shop 32 oz or the bundle. natureswaysoil.com/dog-urine-lawn-repair',
+    28,
+    4
+  );
+  const lines = wrapped.split('\n');
+
+  assert.ok(lines.length <= 4);
+  assert.ok(lines.every((line) => line.length <= 28), wrapped);
+  assert.equal(lines.join(' ').replace(/\s+/g, ''), 'Shop32ozorthebundle.natureswaysoil.com/dog-urine-lawn-repair');
+});


### PR DESCRIPTION
## What changed
- route the test workflow through the production-quality video generator
- require Pexels footage and OpenAI narration credentials, with Secret Manager fallback
- add narration before artifact upload
- enforce resolution, duration, audio, and file-size publishing gates

## Root cause
The workflow used the lightweight test generator and only printed ffprobe output. It therefore reported success for a 540x960, 16-second, low-bitrate video that bypassed production QA.

## Validation
- workflow YAML parsed successfully
- `node --test scripts/tests/video-publish-qa.test.mjs` (3 passing)
- `git diff --check`
