### PR TITLE
Install video QA tools for social posting

### DIFF
--- a/.github/workflows/manual-social-post.yml
+++ b/.github/workflows/manual-social-post.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install FFmpeg video inspection tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          ffprobe -version
+
       - name: Check required GitHub secret
         env:
           GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}

--- a/scripts/lib/video-publish-qa.mjs
+++ b/scripts/lib/video-publish-qa.mjs
@@ -33,10 +33,28 @@ export function validateVideoForPublishing(videoPath, { ffprobe = 'ffprobe' } = 
     '-of', 'json',
     videoPath
   ], { encoding: 'utf8', timeout: 30_000 });
-  if (result.status !== 0) {
-    throw new Error(`Video QA could not inspect ${videoPath}: ${String(result.stderr || '').trim()}`);
+  if (result.error) {
+    throw new Error(
+      `Video QA could not start ${ffprobe} for ${videoPath}: ${result.error.message}`
+    );
   }
-  const probe = JSON.parse(result.stdout || '{}');
+  if (result.signal) {
+    throw new Error(
+      `Video QA inspection was terminated by ${result.signal} for ${videoPath}`
+    );
+  }
+  if (result.status !== 0) {
+    const details = String(result.stderr || result.stdout || `exit ${result.status}`).trim();
+    throw new Error(`Video QA could not inspect ${videoPath}: ${details}`);
+  }
+  let probe;
+  try {
+    probe = JSON.parse(result.stdout || '{}');
+  } catch (error) {
+    throw new Error(
+      `Video QA received invalid ffprobe output for ${videoPath}: ${error.message}`
+    );
+  }
   const assessment = assessVideoProbe({
     ...probe,
     fileSize: fs.statSync(videoPath).size

--- a/scripts/tests/video-publish-qa.test.mjs
+++ b/scripts/tests/video-publish-qa.test.mjs
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { assessVideoProbe } from '../lib/video-publish-qa.mjs';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { assessVideoProbe, validateVideoForPublishing } from '../lib/video-publish-qa.mjs';
 import { buildForcedSocialContent } from '../social-caption-overrides.mjs';
 
 test('rejects the low-resolution fallback video that reached YouTube', () => {
@@ -29,6 +32,17 @@ test('accepts a production vertical video with audio', () => {
   });
 
   assert.equal(result.ok, true);
+});
+
+test('reports a missing ffprobe executable instead of an empty inspection error', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'video-qa-'));
+  const video = path.join(dir, 'video.mp4');
+  fs.writeFileSync(video, 'not-a-video');
+
+  assert.throws(
+    () => validateVideoForPublishing(video, { ffprobe: 'definitely-missing-ffprobe' }),
+    /could not start.*ENOENT/i,
+  );
 });
 
 test('does not prefix the website onto an absolute checkout URL', () => {


### PR DESCRIPTION
## What changed
- install FFmpeg/ffprobe in the scheduled and manual social-post workflow
- report process startup errors, signals, exit details, and malformed probe output from video QA
- add regression coverage for a missing ffprobe executable

## Root cause
The social workflow enforced video QA but did not install ffprobe. Node returned a spawn error with an empty stderr string, so the job failed before posting with no actionable reason.

## Validation
- `node --test scripts/tests/video-publish-qa.test.mjs` (4 passing)
- workflow YAML parsed successfully
- `node --check scripts/lib/video-publish-qa.mjs`
- `git diff --check`
