### PR TITLE
Guarantee paid-order email and packing-slip notifications

### DIFF
--- a/lib/paymentIntentOrder.ts
+++ b/lib/paymentIntentOrder.ts
@@ -36,7 +36,7 @@ function addressHtml(address: Stripe.Address | null | undefined): string {
 
 export async function sendPaymentIntentOrderNotification(
   paymentIntent: Stripe.PaymentIntent,
-  stripeEventId: string,
+  _idempotencyReference?: string,
 ) {
   if (!process.env.RESEND_API_KEY) {
     throw new Error('RESEND_API_KEY is not configured');
@@ -77,7 +77,7 @@ export async function sendPaymentIntentOrderNotification(
         <a href="https://dashboard.stripe.com/payments/${encodeURIComponent(paymentIntent.id)}" style="background:#111827;color:white;padding:10px 20px;text-decoration:none;border-radius:4px">View in Stripe</a>
       </p>
     `,
-  }, { idempotencyKey: `stripe-order/${stripeEventId}` });
+  }, { idempotencyKey: `stripe-order/${paymentIntent.id}` });
 
   if (error) throw error;
   return data;

--- a/pages/api/confirm-payment.ts
+++ b/pages/api/confirm-payment.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { getServiceSupabase } from '../../lib/supabase';
+import { sendPaymentIntentOrderNotification } from '../../lib/paymentIntentOrder';
 
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
 
@@ -51,6 +52,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         await supabase.from('orders').update({ status: 'paid' }).eq('pi_id', paymentIntent.id);
       } catch (databaseError) {
         console.warn('Unable to update order status:', databaseError);
+      }
+      try {
+        await sendPaymentIntentOrderNotification(paymentIntent, `confirm-${paymentIntent.id}`);
+      } catch (notificationError) {
+        // Payment is complete; notification failure must not change checkout status.
+        console.error('Order notification fallback failed:', notificationError);
       }
     }
 

--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -4,6 +4,7 @@ import { Resend } from 'resend';
 import { getServiceSupabase } from '../../../lib/supabase';
 import { sendOrderConfirmation } from '../../../lib/resend';
 
+import { sendPaymentIntentOrderNotification } from '../../../lib/paymentIntentOrder';
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2023-10-16',
 });
@@ -214,6 +215,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (event.type === 'checkout.session.completed') {
       const session = event.data.object as Stripe.Checkout.Session;
       await processCheckoutSessionCompleted(session.id);
+    } else if (event.type === 'payment_intent.succeeded') {
+      await sendPaymentIntentOrderNotification(
+        event.data.object as Stripe.PaymentIntent,
+        event.id,
+      );
     }
   } catch (err) {
     console.error('Webhook processing error:', err);


### PR DESCRIPTION
## Cause
The storefront uses raw PaymentIntents, while the documented webhook handler only processed Checkout Sessions. The successful order reached confirm-payment but no notification path.

## Fix
- send an idempotent order notification from confirm-payment after Stripe verifies payment succeeded
- handle payment_intent.succeeded on the documented webhook route too
- use the PaymentIntent ID as the Resend idempotency key so webhook and confirmation cannot duplicate email

## Verification
- npm run type-check
- npm run build
- git diff --check