### PR TITLE
Add revenue lifecycle agents

### DIFF
--- a/config/product-economics.json
+++ b/config/product-economics.json
@@ -1,0 +1,5 @@
+{
+  "description": "Estimated gross-margin rates used only to prioritize organic social promotion. Replace estimates with verified COGS.",
+  "defaultMarginRate": 0.5,
+  "marginRates": {}
+}

--- a/pages/api/abandoned-cart.ts
+++ b/pages/api/abandoned-cart.ts
@@ -1,28 +1,23 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getServiceSupabase } from '../../lib/supabase';
+import { Resend } from 'resend';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
-
   const { email, productId, value } = req.body;
-
-  if (!email || !email.includes('@')) {
-    return res.status(400).json({ error: 'Valid email required' });
-  }
-
-  try {
-    const supabase = getServiceSupabase();
-
-    await supabase.from('abandoned_carts').insert({
-      email,
-      product_id: productId,
-      value,
-      status: 'open',
-      created_at: new Date().toISOString()
-    });
-
-    return res.status(200).json({ ok: true });
-  } catch (e) {
-    return res.status(200).json({ ok: true });
-  }
+  if (!email || !String(email).includes('@')) return res.status(400).json({ error: 'Valid email required' });
+  if (!process.env.RESEND_API_KEY) return res.status(503).json({ error: 'Recovery email is not configured' });
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const site = (process.env.NEXT_PUBLIC_SITE_URL || 'https://natureswaysoil.com').replace(/\/$/, '');
+  const params = new URLSearchParams({ coupon: 'SAVE15' });
+  if (productId) params.set('productId', String(productId));
+  const bucket = Math.floor(Date.now() / 3600000);
+  const { error } = await resend.emails.send({
+    from: process.env.RESEND_FROM || "Nature's Way Soil <no-reply@natureswaysoil.com>",
+    to: [String(email).trim().toLowerCase()],
+    subject: 'Your Nature?s Way Soil cart is saved',
+    html: `<h2>Your cart is waiting</h2><p>Return when you are ready to complete your soil-care order${value ? ` valued at $${Number(value).toFixed(2)}` : ''}. First-time direct customers can use SAVE15.</p><p><a href="${site}/checkout?${params}">Return to checkout</a></p>`,
+    scheduledAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  }, { idempotencyKey: `abandoned-cart/${productId || 'shop'}/${bucket}/${Buffer.from(String(email)).toString('base64url').slice(0, 40)}` });
+  if (error) return res.status(502).json({ error: 'Unable to schedule recovery email' });
+  return res.status(200).json({ ok: true, scheduled: true });
 }

--- a/pages/api/cron/revenue-agents.ts
+++ b/pages/api/cron/revenue-agents.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { Resend } from 'resend';
+
+const site = (process.env.NEXT_PUBLIC_SITE_URL || 'https://natureswaysoil.com').replace(/\/$/, '');
+const from = process.env.RESEND_FROM || "Nature's Way Soil <no-reply@natureswaysoil.com>";
+const email = (pi: Stripe.PaymentIntent) => pi.receipt_email || pi.metadata?.email || '';
+const product = (pi: Stripe.PaymentIntent) => ({ id: pi.metadata?.product_id || '', name: pi.metadata?.product_name || pi.description || 'your soil-care product' });
+const checkout = (pi: Stripe.PaymentIntent, coupon = '') => {
+  const p = new URLSearchParams();
+  if (product(pi).id) p.set('productId', product(pi).id);
+  if (coupon) p.set('coupon', coupon);
+  return `${site}/checkout?${p}`;
+};
+
+async function send(resend: Resend, pi: Stripe.PaymentIntent, kind: string, subject: string, message: string, href: string, dry: boolean) {
+  if (!email(pi)) return false;
+  if (dry) return true;
+  const { error } = await resend.emails.send({
+    from, to: [email(pi)], subject,
+    html: `<div style="font-family:Arial;max-width:620px;margin:auto"><h2 style="color:#2d5016">${subject}</h2><p>${message}</p><p><a href="${href}" style="background:#2d5016;color:#fff;padding:12px 20px;text-decoration:none;border-radius:6px">Continue</a></p><small>Nature's Way Soil</small></div>`,
+  }, { idempotencyKey: `revenue-agent/${kind}/${pi.id}` });
+  if (error) throw error;
+  return true;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const token = req.headers.authorization?.replace(/^Bearer\s+/i, '') || String(req.query.secret || '');
+  if (!process.env.CRON_SECRET || token !== process.env.CRON_SECRET) return res.status(401).json({ error: 'Unauthorized' });
+  if (!process.env.STRIPE_SECRET_KEY || !process.env.RESEND_API_KEY) return res.status(503).json({ error: 'Revenue agents are not configured' });
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const dry = req.query.dry_run === 'true';
+  const now = Math.floor(Date.now() / 1000);
+  const intents = (await stripe.paymentIntents.list({ limit: 100, created: { gte: now - 100 * 86400 } })).data;
+  const result: Record<string, number> = { cart: 0, failed: 0, upsell: 0, review: 0, reorder: 0, errors: 0 };
+  for (const pi of intents) {
+    const h = (now - pi.created) / 3600;
+    const p = product(pi);
+    const tasks: Array<[string,string,string,string]> = [];
+    if (['requires_payment_method','requires_confirmation','requires_action'].includes(pi.status) && h >= 1 && h < 25) tasks.push(['cart', `Still interested in ${p.name}?`, `Your order is waiting. Use SAVE15 if this is your first direct purchase.`, checkout(pi, 'SAVE15')]);
+    if (pi.status === 'requires_payment_method' && pi.last_payment_error && h < 48) tasks.push(['failed','Your payment needs attention',`Stripe could not complete payment for ${p.name}. No additional charge was made.`,checkout(pi)]);
+    if (pi.status === 'succeeded' && h >= 72 && h < 96) tasks.push(['upsell','Build a stronger soil-care routine',`Liquid biochar, kelp, and humic support can complement ${p.name}.`,`${site}/shop`]);
+    if (pi.status === 'succeeded' && h >= 240 && h < 288) tasks.push(['review','How is your soil responding?',`We hope ${p.name} is working well. Share honest feedback or ask for application help.`,`${site}/contact?topic=review`]);
+    if (pi.status === 'succeeded' && h >= 720 && h < 768) tasks.push(['reorder',`Time to check your ${p.name} supply`,'If your supply is running low, you can reorder directly.',checkout(pi)]);
+    for (const [kind,subject,message,href] of tasks) {
+      try { if (await send(resend, pi, kind, subject, message, href, dry)) result[kind] += 1; }
+      catch (error) { result.errors += 1; console.error('[revenue-agent]', kind, pi.id, error); }
+    }
+  }
+  return res.status(200).json({ success: true, dry_run: dry, scanned: intents.length, result });
+}

--- a/pages/api/government-rfq.ts
+++ b/pages/api/government-rfq.ts
@@ -138,6 +138,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (err2) throw err2;
 
+    const rfqKey = Buffer.from(`${agency}|${email}`).toString('base64url').slice(0, 80);
+    for (const delayHours of [24, 72]) {
+      const { error: reminderError } = await resend.emails.send({
+        from: fromAddress,
+        to: NOTIFY_TO.length > 0 ? NOTIFY_TO : [fromAddress],
+        replyTo: email,
+        subject: `[RFQ FOLLOW-UP] ${agency} ? ${delayHours === 24 ? '1 day' : '3 days'}`,
+        html: `<h2>Government lead follow-up</h2><p>Confirm that <strong>${name}</strong> at <strong>${agency}</strong> received a personal response and quote.</p><p>Reply directly to contact ${email}${phone ? ` or ${phone}` : ''}.</p><p>Use case: ${useCase || 'Not specified'}</p>`,
+        scheduledAt: new Date(Date.now() + delayHours * 60 * 60 * 1000).toISOString(),
+      }, { idempotencyKey: `rfq-followup/${rfqKey}/${delayHours}h` });
+      if (reminderError) throw reminderError;
+    }
     return res.status(200).json({ success: true });
 
   } catch (error) {

--- a/scripts/update-social-weights-from-stripe.mjs
+++ b/scripts/update-social-weights-from-stripe.mjs
@@ -9,6 +9,7 @@ const __dirname = path.dirname(__filename);
 const PROJECT = path.resolve(__dirname, '..');
 
 const PERFORMANCE_FILE = path.join(PROJECT, 'config', 'social-performance.json');
+const ECONOMICS_FILE = path.join(PROJECT, 'config', 'product-economics.json');
 const TOP_PRODUCTS_FILE = path.join(PROJECT, 'config', 'top-products.json');
 
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
@@ -92,8 +93,8 @@ async function fetchRecentSales() {
 function calculateScore(record, rules) {
   const clicks = Number(record.clicks || 0);
   const orders = Number(record.orders || 0);
-  const revenue = Number(record.revenue || 0);
-  return orders * Number(rules.ordersWeight || 4) + revenue * Number(rules.revenueWeight || 0.05) + clicks * Number(rules.clicksWeight || 0.1);
+  const profit = Number(record.estimatedProfit || 0);
+  return orders * Number(rules.ordersWeight || 4) + profit * Number(rules.profitWeight || rules.revenueWeight || 0.05) + clicks * Number(rules.clicksWeight || 0.1);
 }
 
 function scoreToWeight(score, perf) {
@@ -109,6 +110,8 @@ async function main() {
     mode: 'weighted', minWeight: 1, maxWeight: 8, defaultWeight: 3,
     weights: {}, performance: {}, rules: { ordersWeight: 4, revenueWeight: 0.05, clicksWeight: 0.1 }
   });
+  const economics = readJson(ECONOMICS_FILE, { defaultMarginRate: 0.5, marginRates: {} });
+
 
   const topProducts = readJson(TOP_PRODUCTS_FILE, { topProducts: [] }).topProducts || [];
   const sales = await fetchRecentSales();
@@ -124,6 +127,8 @@ async function main() {
     };
 
     merged.score = calculateScore(merged, perf.rules || {});
+    merged.marginRate = Number(economics.marginRates?.[product.id] ?? economics.defaultMarginRate ?? 0.5);
+    merged.estimatedProfit = merged.revenue * merged.marginRate;
     perf.performance = perf.performance || {};
     perf.weights = perf.weights || {};
     perf.performance[product.id] = merged;

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-  "version": 2
+  "version": 2,
+  "crons": [
+    {
+      "path": "/api/cron/revenue-agents",
+      "schedule": "17 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Revenue agents
- hourly abandoned-cart and failed-payment recovery
- three-day complementary-product upsells
- ten-day review requests
- thirty-day reorder reminders
- durable RFQ owner reminders at one and three days
- estimated-margin-aware social promotion weighting
- Resend idempotency prevents duplicate lifecycle sends
- Stripe is the canonical order source, avoiding the broken Supabase dependency

## Safety
- cron endpoint requires CRON_SECRET
- payment recovery does not capture or charge payments
- narrow time windows and stable idempotency keys

## Verification
- npm run type-check
- npm run build
- git diff --check