### PR TITLE
Add quick-add multi-item cart and checkout upsells

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,6 +12,7 @@ export default function Header({ transparent = false }: HeaderProps) {
   const navigation = [
     { name: 'Home', href: '/' },
     { name: 'Shop', href: '/shop' },
+    { name: 'Cart', href: '/cart' },
     { name: 'Solutions', href: '/solutions' },
     { name: 'Lawn Recovery', href: '/homeowners-landscapers-government' },
     { name: 'Government', href: '/government' },

--- a/components/QuickAddButton.tsx
+++ b/components/QuickAddButton.tsx
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+import { addCartItem } from '../lib/cart';
+
+type Props = { productId:string; productName:string; image?:string; price:number; sizeName?:string; sku?:string };
+export default function QuickAddButton(props:Props) {
+  const [added,setAdded]=useState(false);
+  return <button onClick={()=>{addCartItem({...props,quantity:1});setAdded(true);window.location.assign('/cart');}} className="btn-primary text-sm py-2 px-3">{added?'Added ✓':'Quick Add'}</button>;
+}

--- a/lib/cart.ts
+++ b/lib/cart.ts
@@ -1,0 +1,33 @@
+export const CART_KEY = 'nws-cart-v1';
+export const CART_EVENT = 'nws_cart_changed';
+
+export type CartItem = {
+  productId: string;
+  productName: string;
+  sizeName?: string;
+  sku?: string;
+  image?: string;
+  price: number;
+  quantity: number;
+};
+
+export function readCart(): CartItem[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const value = JSON.parse(window.localStorage.getItem(CART_KEY) || '[]');
+    return Array.isArray(value) ? value : [];
+  } catch { return []; }
+}
+
+export function writeCart(items: CartItem[]) {
+  window.localStorage.setItem(CART_KEY, JSON.stringify(items));
+  window.dispatchEvent(new CustomEvent(CART_EVENT));
+}
+
+export function addCartItem(item: CartItem) {
+  const items = readCart();
+  const index = items.findIndex((x) => x.productId === item.productId && x.sku === item.sku);
+  if (index >= 0) items[index] = { ...items[index], quantity: items[index].quantity + item.quantity };
+  else items.push(item);
+  writeCart(items.slice(0, 12));
+}

--- a/pages/api/create-cart-checkout-session.ts
+++ b/pages/api/create-cart-checkout-session.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { allProducts } from '../../data/products';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', { apiVersion: '2023-10-16' });
+type RequestedItem = { productId?:string; sku?:string; quantity?:number };
+
+function path(value:unknown, fallback:string) {
+  return typeof value === 'string' && value.startsWith('/') && !value.startsWith('//') ? value : fallback;
+}
+
+export default async function handler(req:NextApiRequest,res:NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({error:'Method not allowed'});
+  if (!process.env.STRIPE_SECRET_KEY) return res.status(503).json({error:'Checkout is not configured'});
+  const requested = (Array.isArray(req.body?.items) ? req.body.items : []).slice(0,12) as RequestedItem[];
+  if (!requested.length) return res.status(400).json({error:'Your cart is empty'});
+
+  const normalized = requested.map((item) => {
+    const product = allProducts.find((p) => p.id === item.productId);
+    if (!product || !product.inStock) throw new Error('One of the selected products is unavailable');
+    const size = product.sizes?.find((s) => s.sku === item.sku) || product.sizes?.[0];
+    const price = size?.price ?? product.price;
+    return { product, size, quantity:Math.min(20,Math.max(1,Math.floor(Number(item.quantity)||1))), price };
+  });
+  const subtotal = normalized.reduce((sum,x)=>sum+Math.round(x.price*100)*x.quantity,0);
+  const shipping = subtotal >= 5000 ? 0 : 995;
+  const origin = req.headers.origin || process.env.NEXT_PUBLIC_SITE_URL || 'https://natureswaysoil.com';
+  const successPath = path(req.body?.successPath,'/cart-success?session_id={CHECKOUT_SESSION_ID}');
+  const cancelPath = path(req.body?.cancelPath,'/cart');
+  const summary = normalized.map(x=>`${x.quantity}x ${x.product.id}`).join(', ').slice(0,500);
+  const totalQty = normalized.reduce((sum,x)=>sum+x.quantity,0);
+  const metadata = { product_id:'CART', product_name:`Multi-item order: ${summary}`.slice(0,500), size_name:'See packing slip', sku:normalized.map(x=>x.size?.sku||x.product.id).join(',').slice(0,500), quantity:String(totalQty), subtotal_cents:String(subtotal), shipping_cents:String(shipping), source:'website-cart' };
+  const lineItems:Stripe.Checkout.SessionCreateParams.LineItem[] = normalized.map(({product,size,quantity,price})=>({ price_data:{currency:'usd',unit_amount:Math.round(price*100),product_data:{name:size?.name?`${product.name} – ${size.name}`:product.name,metadata:{productId:product.id,sizeName:size?.name||'',sku:size?.sku||product.id}}},quantity }));
+
+  try {
+    const session=await stripe.checkout.sessions.create({mode:'payment',payment_method_types:['card','link'],line_items:lineItems,shipping_options:shipping?[{shipping_rate_data:{type:'fixed_amount',fixed_amount:{amount:shipping,currency:'usd'},display_name:'Standard Shipping'}}]:undefined,billing_address_collection:'auto',shipping_address_collection:{allowed_countries:['US']},phone_number_collection:{enabled:true},allow_promotion_codes:true,metadata,payment_intent_data:{metadata},success_url:`${origin}${successPath}`,cancel_url:`${origin}${cancelPath}`});
+    return res.status(200).json({url:session.url});
+  } catch(error) { console.error('[cart-checkout]',error); return res.status(500).json({error:'Unable to start secure checkout'}); }
+}

--- a/pages/api/webhooks/stripe.ts
+++ b/pages/api/webhooks/stripe.ts
@@ -120,7 +120,8 @@ async function processCheckoutSessionCompleted(sessionId: string) {
     expand: ['line_items.data.price.product'],
   });
 
-  const lineItem = session.line_items?.data?.[0];
+  const productLineItems = (session.line_items?.data || []).filter((item) => item.description !== 'Standard Shipping');
+  const lineItem = productLineItems[0];
   const metadata = session.metadata || {};
   const productName = metadata.productName || metadata.product_name || lineItem?.description || 'Nature’s Way Soil Product';
   const sizeName = metadata.sizeName || metadata.size_name || '';
@@ -168,13 +169,12 @@ async function processCheckoutSessionCompleted(sessionId: string) {
     await sendOrderConfirmation(customerEmail, {
       orderId: session.id,
       name: customerName,
-      items: [{
-        title: productName,
-        size: sizeName || undefined,
-        qty: quantity,
-        price: (lineItem?.amount_subtotal || Number(metadata.subtotal_cents || session.amount_subtotal || 0)) / 100,
-        sku,
-      }],
+      items: productLineItems.length ? productLineItems.map((item) => ({
+        title: item.description || productName,
+        qty: item.quantity || 1,
+        price: (item.amount_subtotal || 0) / 100,
+        sku: '',
+      })) : [{ title: productName, size: sizeName || undefined, qty: quantity, price: (lineItem?.amount_subtotal || Number(metadata.subtotal_cents || session.amount_subtotal || 0)) / 100, sku }],
       subtotal: (session.amount_subtotal || 0) / 100,
       tax: (session.total_details?.amount_tax || 0) / 100,
       shipping: (session.total_details?.amount_shipping || 0) / 100,

--- a/pages/cart-success.tsx
+++ b/pages/cart-success.tsx
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { useEffect } from 'react';
+import Layout from '../components/Layout';
+import { CART_KEY, CART_EVENT } from '../lib/cart';
+
+export default function CartSuccess() {
+  useEffect(() => { window.localStorage.removeItem(CART_KEY); window.dispatchEvent(new CustomEvent(CART_EVENT)); }, []);
+  return <Layout><Head><title>Order Received - Nature&apos;s Way Soil</title><meta name="robots" content="noindex"/></Head><main className="max-w-3xl mx-auto px-4 py-16">
+    <div className="bg-white border rounded-2xl p-8 text-center"><div className="text-5xl mb-4">✓</div><h1 className="text-3xl font-bold mb-3">Thank you for your order!</h1><p className="text-gray-600 mb-8">Your payment was received. We will email your confirmation and prepare every item for shipment.</p>
+      <div className="bg-green-50 border border-green-200 rounded-xl p-6 mb-7"><h2 className="font-bold text-xl mb-2">Build an even stronger soil-care routine</h2><p className="text-gray-700 mb-4">Customers often pair their order with living compost, liquid biochar, or humic and kelp support.</p><Link href="/upsell" className="btn-primary">See Recommended Add-ons</Link></div>
+      <Link href="/shop" className="underline">Continue Shopping</Link></div>
+  </main></Layout>;
+}

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,0 +1,48 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import Layout from '../components/Layout';
+import { CartItem, readCart, writeCart } from '../lib/cart';
+import { allProducts } from '../data/products';
+
+const FREE_SHIPPING = 50;
+
+export default function CartPage() {
+  const [items, setItems] = useState<CartItem[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  useEffect(() => setItems(readCart()), []);
+  const subtotal = useMemo(() => items.reduce((sum, x) => sum + x.price * x.quantity, 0), [items]);
+  const remaining = Math.max(0, FREE_SHIPPING - subtotal);
+  const suggestion = allProducts
+    .flatMap((p) => (p.sizes || [{ name: '', price: p.price, sku: p.id }]).map((s) => ({ product: p, size: s })))
+    .filter(({ product, size }) => !items.some((x) => x.productId === product.id && x.sku === size.sku) && size.price >= remaining)
+    .sort((a, b) => a.size.price - b.size.price)[0];
+
+  const update = (index:number, quantity:number) => {
+    const next = items.map((x, i) => i === index ? { ...x, quantity: Math.max(0, quantity) } : x).filter((x) => x.quantity > 0);
+    setItems(next); writeCart(next);
+  };
+  const checkout = async () => {
+    setBusy(true); setError('');
+    try {
+      const response = await fetch('/api/create-cart-checkout-session', { method:'POST', headers:{'content-type':'application/json'}, body:JSON.stringify({ items, successPath:'/cart-success?session_id={CHECKOUT_SESSION_ID}', cancelPath:'/cart' }) });
+      const data = await response.json();
+      if (!response.ok || !data.url) throw new Error(data.error || 'Unable to start checkout');
+      window.location.assign(data.url);
+    } catch (e) { setError(e instanceof Error ? e.message : 'Unable to start checkout'); setBusy(false); }
+  };
+
+  return <Layout><Head><title>Your Cart - Nature&apos;s Way Soil</title></Head><main className="max-w-5xl mx-auto px-4 py-12">
+    <h1 className="text-3xl font-bold mb-8">Your Cart</h1>
+    {!items.length ? <div className="bg-white border rounded-2xl p-10 text-center"><p className="text-lg mb-5">Your cart is empty.</p><Link href="/shop" className="btn-primary">Shop Products</Link></div> : <div className="grid lg:grid-cols-3 gap-8">
+      <section className="lg:col-span-2 space-y-4">{items.map((x,i)=><article key={`${x.productId}-${x.sku}`} className="bg-white border rounded-xl p-4 flex gap-4">
+        {x.image && <img src={x.image} alt="" className="w-24 h-24 object-contain"/>}<div className="flex-1"><h2 className="font-semibold">{x.productName}</h2><p className="text-sm text-gray-500">{x.sizeName}</p><p className="font-bold text-green-700 mt-2">${x.price.toFixed(2)}</p></div>
+        <div className="flex items-center gap-2"><button onClick={()=>update(i,x.quantity-1)} className="border rounded px-3 py-1">−</button><span>{x.quantity}</span><button onClick={()=>update(i,x.quantity+1)} className="border rounded px-3 py-1">+</button></div>
+      </article>)}</section>
+      <aside className="bg-white border rounded-2xl p-6 h-fit space-y-5"><div className="flex justify-between text-lg font-bold"><span>Subtotal</span><span>${subtotal.toFixed(2)}</span></div>
+        {remaining > 0 ? <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm"><strong>Add ${remaining.toFixed(2)} for free shipping.</strong>{suggestion && <button onClick={()=>{ const s=suggestion.size; const next=[...items,{productId:suggestion.product.id,productName:suggestion.product.name,sizeName:s.name,sku:s.sku,image:suggestion.product.image,price:s.price,quantity:1}]; setItems(next); writeCart(next); }} className="block mt-3 text-green-700 font-semibold text-left">+ Add {suggestion.product.name} (${suggestion.size.price.toFixed(2)})</button>}</div> : <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-green-800 font-semibold">✓ Free shipping unlocked</div>}
+        {error && <p className="text-red-700 text-sm">{error}</p>}<button onClick={checkout} disabled={busy} className="btn-primary w-full disabled:opacity-50">{busy?'Opening secure checkout…':'Secure Checkout'}</button><Link href="/shop" className="block text-center underline text-sm">Continue shopping</Link>
+      </aside></div>}
+  </main></Layout>;
+}

--- a/pages/shop.tsx
+++ b/pages/shop.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { Grid, List, Search } from 'lucide-react';
 import Layout from '../components/Layout';
 import { allProducts } from '../data/products';
+import QuickAddButton from '../components/QuickAddButton';
 
 interface Product {
   id: string;
@@ -207,13 +208,10 @@ export default function Shop({ products, categories }: ShopProps) {
                         </span>
                       )}
                     </div>
-                    
-                    <Link 
-                      href={`/product/${product.id}`}
-                      className="btn-primary text-sm py-2 px-4"
-                    >
-                      View Details
-                    </Link>
+                    <div className="flex flex-col gap-2 min-w-[110px]">
+                      <QuickAddButton productId={product.id} productName={product.name} image={product.image} price={product.price} sizeName={allProducts.find((p) => p.id === product.id)?.sizes?.[0]?.name} sku={allProducts.find((p) => p.id === product.id)?.sizes?.[0]?.sku} />
+                      <Link href={`/product/${product.id}`} className="text-center text-xs underline text-gray-600">View details</Link>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Adds Quick Add on the shop, a persistent multi-item cart, free-shipping companion recommendations, server-validated Stripe hosted checkout, itemized confirmation emails, a Cart navigation link, and a connected post-purchase add-on offer. Verified with npm run type-check, npm run build, and git diff --check.