### PR TITLE
Add soil advisor and coordinated revenue agents

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,6 +14,7 @@ export default function Header({ transparent = false }: HeaderProps) {
     { name: 'Shop', href: '/shop' },
     { name: 'Cart', href: '/cart' },
     { name: 'Solutions', href: '/solutions' },
+    { name: 'Soil Advisor', href: '/soil-advisor' },
     { name: 'Lawn Recovery', href: '/homeowners-landscapers-government' },
     { name: 'Government', href: '/government' },
     { name: 'Blog', href: '/blog' },

--- a/pages/api/cron/business-intelligence.ts
+++ b/pages/api/cron/business-intelligence.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest,NextApiResponse } from 'next';
+import Stripe from 'stripe';
+import { Resend } from 'resend';
+import economics from '../../../config/product-economics.json';
+import { getServiceSupabase } from '../../../lib/supabase';
+
+const owner=process.env.SALES_TO||process.env.JAMES_TO||'natureswaysoil@gmail.com';
+const from=process.env.RESEND_FROM||"Nature's Way Soil <no-reply@natureswaysoil.com>";
+const safe=(v:unknown)=>String(v??'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+const seasonal=(month:number)=> month<=2?'Prepare spring lawn, garden, and pasture campaigns.':month<=5?'Prioritize lawns, transplants, tomatoes, and pet-lawn recovery.':month<=8?'Prioritize drought stress, water retention, kelp, humic, and biochar.':month<=10?'Prioritize overseeding, lawn recovery, compost, and soil rebuilding.':'Prioritize giftable garden products and next-season soil preparation.';
+
+export default async function handler(req:NextApiRequest,res:NextApiResponse){
+  const token=req.headers.authorization?.replace(/^Bearer\s+/i,'')||String(req.query.secret||'');
+  if(!process.env.CRON_SECRET||token!==process.env.CRON_SECRET)return res.status(401).json({error:'Unauthorized'});
+  if(!process.env.STRIPE_SECRET_KEY)return res.status(503).json({error:'Stripe not configured'});
+  const dry=req.query.dry_run==='true',stripe=new Stripe(process.env.STRIPE_SECRET_KEY,{apiVersion:'2023-10-16'}),now=Math.floor(Date.now()/1000);
+  const intents=(await stripe.paymentIntents.list({limit:100,created:{gte:now-30*86400}})).data.filter(x=>x.status==='succeeded');
+  const byProduct=new Map<string,{name:string,revenue:number,orders:number}>();
+  for(const pi of intents){const id=pi.metadata?.product_id||'unknown',name=pi.metadata?.product_name||pi.description||id,current=byProduct.get(id)||{name,revenue:0,orders:0};current.revenue+=(pi.amount_received||pi.amount)/100;current.orders++;byProduct.set(id,current);}
+  const marginRates=(economics.marginRates||{}) as Record<string,number>,defaultRate=Number(economics.defaultMarginRate||0);
+  const rows=Array.from(byProduct.entries()).map(([id,x])=>({...x,id,margin:marginRates[id],estimatedProfit:x.revenue*(marginRates[id]??defaultRate)})).sort((a,b)=>b.estimatedProfit-a.estimatedProfit);
+  const notes=[seasonal(new Date().getUTCMonth()+1),Object.keys(marginRates).length?'Verified product margin overrides are active.':'COGS is missing; profit uses the configured estimated default margin and must not drive automatic price changes.'];
+  let inventory={tracked:0,out_of_stock:0,note:'Inventory quantities are not configured; only in-stock status can be monitored.'};
+  try{const db=getServiceSupabase();const {data}=await db.from('products').select('id,in_stock');const records=data||[];inventory={tracked:records.length,out_of_stock:records.filter((x:any)=>x.in_stock===false).length,note:records.length?'Product availability status loaded from Supabase.':'No inventory records found in Supabase.'};}catch{notes.push('Supabase inventory status was unavailable for this run.');}
+  notes.push(`Inventory: ${inventory.tracked} products tracked, ${inventory.out_of_stock} marked out of stock. ${inventory.note}`);
+  if(!dry&&process.env.RESEND_API_KEY){const resend=new Resend(process.env.RESEND_API_KEY),day=new Date().toISOString().slice(0,10);await resend.emails.send({from,to:[owner],subject:`[Revenue Brief] ${intents.length} paid orders in the last 30 days`,html:`<h2>Nature's Way Soil revenue intelligence</h2><p>${safe(notes.join(' '))}</p><table cellpadding="7"><tr><th>Product</th><th>Orders</th><th>Revenue</th><th>Estimated profit</th></tr>${rows.map(x=>`<tr><td>${safe(x.name)}</td><td>${x.orders}</td><td>$${x.revenue.toFixed(2)}</td><td>$${x.estimatedProfit.toFixed(2)}${x.margin===undefined?' (estimated)':''}</td></tr>`).join('')}</table>`},{idempotencyKey:`business-intelligence/${day}`});}
+  return res.status(200).json({success:true,dry_run:dry,paid_orders:intents.length,revenue:Number(rows.reduce((s,x)=>s+x.revenue,0).toFixed(2)),estimated_profit:Number(rows.reduce((s,x)=>s+x.estimatedProfit,0).toFixed(2)),verified_margin_products:Object.keys(marginRates).length,inventory,notes,products:dry?rows:undefined});
+}

--- a/pages/api/cron/revenue-agents.ts
+++ b/pages/api/cron/revenue-agents.ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const dry = req.query.dry_run === 'true';
   const now = Math.floor(Date.now() / 1000);
   const intents = (await stripe.paymentIntents.list({ limit: 100, created: { gte: now - 100 * 86400 } })).data;
-  const result: Record<string, number> = { cart: 0, failed: 0, upsell: 0, review: 0, reorder: 0, errors: 0 };
+  const result: Record<string, number> = { cart: 0, failed: 0, upsell: 0, review: 0, referral: 0, reorder: 0, 'reorder-60': 0, errors: 0 };
   for (const pi of intents) {
     const h = (now - pi.created) / 3600;
     const p = product(pi);
@@ -42,7 +42,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (pi.status === 'requires_payment_method' && pi.last_payment_error && h < 48) tasks.push(['failed','Your payment needs attention',`Stripe could not complete payment for ${p.name}. No additional charge was made.`,checkout(pi)]);
     if (pi.status === 'succeeded' && h >= 72 && h < 96) tasks.push(['upsell','Build a stronger soil-care routine',`Liquid biochar, kelp, and humic support can complement ${p.name}.`,`${site}/shop`]);
     if (pi.status === 'succeeded' && h >= 240 && h < 288) tasks.push(['review','How is your soil responding?',`We hope ${p.name} is working well. Share honest feedback or ask for application help.`,`${site}/contact?topic=review`]);
+    if (pi.status === 'succeeded' && h >= 504 && h < 552) tasks.push(['referral','Help a friend solve their soil problem',`If someone you know has a similar lawn or garden problem, share our free product advisor. First-time direct customers can use SAVE15.`,`${site}/soil-advisor?ref=customer`]);
     if (pi.status === 'succeeded' && h >= 720 && h < 768) tasks.push(['reorder',`Time to check your ${p.name} supply`,'If your supply is running low, you can reorder directly.',checkout(pi)]);
+    if (pi.status === 'succeeded' && h >= 1440 && h < 1488) tasks.push(['reorder-60',`Ready for another ${p.name} application?`,'Check your remaining supply and reorder before the next treatment window.',checkout(pi)]);
     for (const [kind,subject,message,href] of tasks) {
       try { if (await send(resend, pi, kind, subject, message, href, dry)) result[kind] += 1; }
       catch (error) { result.errors += 1; console.error('[revenue-agent]', kind, pi.id, error); }

--- a/pages/api/cron/wholesale-leads.ts
+++ b/pages/api/cron/wholesale-leads.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest,NextApiResponse } from 'next';
+import { Resend } from 'resend';
+
+const queries=['landscaping company North Carolina','lawn care company North Carolina','garden center North Carolina','horse farm supply North Carolina','nursery South Carolina','property management landscaping Virginia'];
+const safe=(v:unknown)=>String(v??'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+export default async function handler(req:NextApiRequest,res:NextApiResponse){
+ const token=req.headers.authorization?.replace(/^Bearer\s+/i,'')||String(req.query.secret||''); if(!process.env.CRON_SECRET||token!==process.env.CRON_SECRET)return res.status(401).json({error:'Unauthorized'});
+ const key=process.env.GOOGLE_PLACES_API_KEY,dry=req.query.dry_run==='true'; if(!key)return res.status(200).json({success:true,dry_run:dry,leads:0,notes:['Add GOOGLE_PLACES_API_KEY to activate weekly landscaper, nursery, farm, and property-manager prospect discovery.']});
+ const found=new Map<string,any>(); for(const textQuery of queries){const response=await fetch('https://places.googleapis.com/v1/places:searchText',{method:'POST',headers:{'content-type':'application/json','X-Goog-Api-Key':key,'X-Goog-FieldMask':'places.id,places.displayName,places.formattedAddress,places.websiteUri,places.nationalPhoneNumber,places.googleMapsUri'},body:JSON.stringify({textQuery,pageSize:10})}); if(!response.ok)continue;const data=await response.json();for(const p of data.places||[])found.set(p.id,p);}
+ const leads=Array.from(found.values()).slice(0,50); if(!dry&&process.env.RESEND_API_KEY){const resend=new Resend(process.env.RESEND_API_KEY),week=new Date().toISOString().slice(0,10);await resend.emails.send({from:process.env.RESEND_FROM||"Nature's Way Soil <no-reply@natureswaysoil.com>",to:[process.env.SALES_TO||'natureswaysoil@gmail.com'],subject:`[Wholesale Leads] ${leads.length} landscaper and reseller prospects`,html:`<h2>Wholesale prospect review</h2><p>Use public business contacts only. Personalize and approve outreach before sending.</p><ul>${leads.map(p=>`<li><a href="${safe(p.websiteUri||p.googleMapsUri)}">${safe(p.displayName?.text)}</a> — ${safe(p.formattedAddress)} — ${safe(p.nationalPhoneNumber)}</li>`).join('')}</ul>`},{idempotencyKey:`wholesale-leads/${week}`});}
+ return res.status(200).json({success:true,dry_run:dry,leads:leads.length,preview:dry?leads.slice(0,10):undefined});
+}

--- a/pages/soil-advisor.tsx
+++ b/pages/soil-advisor.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head';
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import Layout from '../components/Layout';
+import { allProducts } from '../data/products';
+import { writeCart } from '../lib/cart';
+
+const plans:Record<string,{title:string;why:string;ids:string[]}>={
+  pet:{title:'Pet Lawn Recovery Plan',why:'Neutralize repeated pet-lawn stress while supporting the root zone.',ids:['NWS_014','NWS_011']},
+  clay:{title:'Compacted Soil Plan',why:'Improve water movement and support stronger roots in tight soil.',ids:['NWS_001','NWS_011']},
+  garden:{title:'Living Garden Plan',why:'Combine living compost with kelp support for beds and transplants.',ids:['NWS_013','NWS_006']},
+  pasture:{title:'Pasture Recovery Plan',why:'Support larger grass areas with a pasture fertilizer and recovery system.',ids:['NWS_021','NWS_022']},
+  lawn:{title:'Lawn Growth Plan',why:'Pair lawn treatment with humic, fulvic, and kelp root-zone support.',ids:['NWS_018','NWS_011']},
+};
+
+export default function SoilAdvisor(){
+  const router=useRouter(); const [problem,setProblem]=useState('pet'); const [area,setArea]=useState('small');
+  const plan=plans[problem]; const products=useMemo(()=>plan.ids.map(id=>allProducts.find(p=>p.id===id)).filter(Boolean),[plan]);
+  const buildCart=()=>{writeCart(products.map((p)=>{const size=p!.sizes?.[area==='large'&&p!.sizes.length>1?1:0];return{productId:p!.id,productName:p!.name,sizeName:size?.name,sku:size?.sku,image:p!.image,price:size?.price??p!.price,quantity:1};}));router.push('/cart');};
+  return <Layout><Head><title>Soil &amp; Lawn Product Advisor | Nature&apos;s Way Soil</title><meta name="description" content="Answer two questions and get a personalized Nature's Way Soil product plan."/></Head><main className="max-w-4xl mx-auto px-4 py-14">
+    <div className="text-center mb-10"><p className="uppercase tracking-widest text-green-700 font-semibold">Free product advisor</p><h1 className="text-4xl font-bold mt-2">What does your soil need?</h1><p className="text-gray-600 mt-3">Answer two quick questions. We&apos;ll build a practical starting plan—no guessing.</p></div>
+    <div className="grid md:grid-cols-2 gap-7"><section className="bg-white border rounded-2xl p-6 space-y-6"><label className="block font-semibold">Main problem<select value={problem} onChange={e=>setProblem(e.target.value)} className="mt-2 w-full border rounded-lg p-3"><option value="pet">Dog urine spots or pet lawn damage</option><option value="clay">Compacted clay or poor drainage</option><option value="garden">Garden beds, vegetables, or transplants</option><option value="pasture">Hay field or pasture recovery</option><option value="lawn">Weak, yellow, or stressed lawn</option></select></label>
+      <label className="block font-semibold">Treatment area<select value={area} onChange={e=>setArea(e.target.value)} className="mt-2 w-full border rounded-lg p-3"><option value="small">Small yard, garden, or spot treatment</option><option value="large">Large lawn, route, farm, or facility</option></select></label><p className="text-xs text-gray-500">Recommendations are general product guidance, not a laboratory soil diagnosis. Application needs vary by soil and site conditions.</p></section>
+      <section className="bg-green-50 border border-green-200 rounded-2xl p-6"><h2 className="text-2xl font-bold">{plan.title}</h2><p className="text-gray-700 mt-2 mb-5">{plan.why}</p><div className="space-y-3">{products.map(p=>{const s=p!.sizes?.[area==='large'&&p!.sizes.length>1?1:0];return <div key={p!.id} className="bg-white rounded-xl p-4 flex justify-between gap-3"><div><strong>{p!.name}</strong><p className="text-sm text-gray-500">{s?.name}</p></div><span className="font-bold text-green-700">${(s?.price??p!.price).toFixed(2)}</span></div>;})}</div><button onClick={buildCart} className="btn-primary w-full mt-6">Build My Recommended Cart</button></section>
+    </div></main></Layout>;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,14 @@
     {
       "path": "/api/cron/government-leads",
       "schedule": "23 12 * * *"
+    },
+    {
+      "path": "/api/cron/business-intelligence",
+      "schedule": "7 13 * * *"
+    },
+    {
+      "path": "/api/cron/wholesale-leads",
+      "schedule": "41 13 * * 1"
     }
   ]
 }


### PR DESCRIPTION
Adds a guided soil diagnosis salesperson with prefilled carts, referral and 60-day reorder lifecycle agents, daily Stripe revenue/profit/seasonal/inventory intelligence, optional weekly Google Places wholesale discovery, navigation, and cron schedules. Missing COGS remains clearly estimated and missing optional credentials fail safely. Verified with npm run type-check, npm run build, and git diff --check.